### PR TITLE
Separate traces max workers param

### DIFF
--- a/airflow/dags/polygon_export_dag.py
+++ b/airflow/dags/polygon_export_dag.py
@@ -12,5 +12,6 @@ DAG = build_export_dag(
         export_start_date='2020-05-30',
         export_max_active_runs=3,
         export_max_workers=5,
+        export_traces_max_workers=10,
     )
 )

--- a/airflow/dags/polygonetl_airflow/build_export_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_export_dag.py
@@ -32,6 +32,7 @@ def build_export_dag(
         notification_emails=None,
         export_schedule_interval='0 0 * * *',
         export_max_workers=10,
+        export_traces_max_workers=10,
         export_batch_size=200,
         export_max_active_runs=None,
         export_retries=5,
@@ -244,7 +245,7 @@ def build_export_dag(
                     end_block=end_block,
                     batch_size=export_traces_batch_size,
                     output=os.path.join(tempdir, "geth_traces.json"),
-                    max_workers=export_max_workers,
+                    max_workers=export_traces_max_workers,
                     provider_uri=provider_uri
                 )
                 copy_to_export_path(

--- a/airflow/dags/polygonetl_airflow/variables.py
+++ b/airflow/dags/polygonetl_airflow/variables.py
@@ -30,6 +30,7 @@ def read_export_dag_vars(var_prefix, **kwargs):
         'notification_emails': read_var('notification_emails', None, False, **kwargs),
         'export_max_active_runs': export_max_active_runs,
         'export_max_workers': int(read_var('export_max_workers', var_prefix, True, **kwargs)),
+        'export_traces_max_workers': int(read_var('export_traces_max_workers', var_prefix, True, **kwargs)),
     }
 
     return vars

--- a/cli/polygonetl/jobs/export_receipts_job.py
+++ b/cli/polygonetl/jobs/export_receipts_job.py
@@ -22,6 +22,7 @@
 
 
 import json
+import logging
 
 from blockchainetl_common.jobs.base_job import BaseJob
 from polygonetl.executors.batch_work_executor import BatchWorkExecutor
@@ -67,6 +68,9 @@ class ExportReceiptsJob(BaseJob):
         response = self.batch_web3_provider.make_batch_request(json.dumps(receipts_rpc))
         results = rpc_response_batch_to_results(response)
         receipts = [self.receipt_mapper.json_dict_to_receipt(result) for result in results]
+        if len(transaction_hashes) != len(receipts):
+            logging.error('The number of receipts is not equal to the number of transaction hashes ' + ','.join(transaction_hashes))
+            raise ValueError('The number of receipts is not equal to the number of transaction hashes.')
         for receipt in receipts:
             self._export_receipt(receipt)
 


### PR DESCRIPTION
- Separate export_max_workers and export_traces_max_workers in export DAG
- Raise an exception when the number of receipts is not equal to the number of transaction hashes in export_receipts_job.py