### PR TITLE
Add fields introduced by EIP-1559

### DIFF
--- a/cli/polygonetl/domain/block.py
+++ b/cli/polygonetl/domain/block.py
@@ -43,3 +43,4 @@ class EthBlock(object):
 
         self.transactions = []
         self.transaction_count = 0
+        self.base_fee_per_gas = 0

--- a/cli/polygonetl/domain/receipt.py
+++ b/cli/polygonetl/domain/receipt.py
@@ -33,3 +33,4 @@ class EthReceipt(object):
         self.logs = []
         self.root = None
         self.status = None
+        self.effective_gas_price = None

--- a/cli/polygonetl/domain/transaction.py
+++ b/cli/polygonetl/domain/transaction.py
@@ -34,3 +34,6 @@ class EthTransaction(object):
         self.gas = None
         self.gas_price = None
         self.input = None
+        self.max_fee_per_gas = None
+        self.max_priority_fee_per_gas = None
+        self.transaction_type = None

--- a/cli/polygonetl/jobs/exporters/blocks_and_transactions_item_exporter.py
+++ b/cli/polygonetl/jobs/exporters/blocks_and_transactions_item_exporter.py
@@ -41,7 +41,8 @@ BLOCK_FIELDS_TO_EXPORT = [
     'gas_limit',
     'gas_used',
     'timestamp',
-    'transaction_count'
+    'transaction_count',
+    'base_fee_per_gas'
 ]
 
 TRANSACTION_FIELDS_TO_EXPORT = [
@@ -56,7 +57,10 @@ TRANSACTION_FIELDS_TO_EXPORT = [
     'gas',
     'gas_price',
     'input',
-    'block_timestamp'
+    'block_timestamp',
+    'max_fee_per_gas',
+    'max_priority_fee_per_gas',
+    'transaction_type'
 ]
 
 

--- a/cli/polygonetl/jobs/exporters/receipts_and_logs_item_exporter.py
+++ b/cli/polygonetl/jobs/exporters/receipts_and_logs_item_exporter.py
@@ -32,7 +32,8 @@ RECEIPT_FIELDS_TO_EXPORT = [
     'gas_used',
     'contract_address',
     'root',
-    'status'
+    'status',
+    'effective_gas_price'
 ]
 
 LOG_FIELDS_TO_EXPORT = [

--- a/cli/polygonetl/mappers/block_mapper.py
+++ b/cli/polygonetl/mappers/block_mapper.py
@@ -52,6 +52,7 @@ class EthBlockMapper(object):
         block.gas_limit = hex_to_dec(json_dict.get('gasLimit'))
         block.gas_used = hex_to_dec(json_dict.get('gasUsed'))
         block.timestamp = hex_to_dec(json_dict.get('timestamp'))
+        block.base_fee_per_gas = hex_to_dec(json_dict.get('baseFeePerGas'))
 
         if 'transactions' in json_dict:
             block.transactions = [
@@ -85,4 +86,5 @@ class EthBlockMapper(object):
             'gas_used': block.gas_used,
             'timestamp': block.timestamp,
             'transaction_count': block.transaction_count,
+            'base_fee_per_gas': block.base_fee_per_gas
         }

--- a/cli/polygonetl/mappers/receipt_mapper.py
+++ b/cli/polygonetl/mappers/receipt_mapper.py
@@ -47,6 +47,7 @@ class EthReceiptMapper(object):
 
         receipt.root = json_dict.get('root')
         receipt.status = hex_to_dec(json_dict.get('status'))
+        receipt.effective_gas_price = hex_to_dec(json_dict.get('effectiveGasPrice'))
 
         if 'logs' in json_dict:
             receipt.logs = [
@@ -66,5 +67,6 @@ class EthReceiptMapper(object):
             'gas_used': receipt.gas_used,
             'contract_address': receipt.contract_address,
             'root': receipt.root,
-            'status': receipt.status
+            'status': receipt.status,
+            'effective_gas_price': receipt.effective_gas_price
         }

--- a/cli/polygonetl/mappers/transaction_mapper.py
+++ b/cli/polygonetl/mappers/transaction_mapper.py
@@ -40,6 +40,9 @@ class EthTransactionMapper(object):
         transaction.gas = hex_to_dec(json_dict.get('gas'))
         transaction.gas_price = hex_to_dec(json_dict.get('gasPrice'))
         transaction.input = json_dict.get('input')
+        transaction.max_fee_per_gas = hex_to_dec(json_dict.get('maxFeePerGas'))
+        transaction.max_priority_fee_per_gas = hex_to_dec(json_dict.get('maxPriorityFeePerGas'))
+        transaction.transaction_type = hex_to_dec(json_dict.get('type'))
         return transaction
 
     def transaction_to_dict(self, transaction):
@@ -57,4 +60,7 @@ class EthTransactionMapper(object):
             'gas': transaction.gas,
             'gas_price': transaction.gas_price,
             'input': transaction.input,
+            'max_fee_per_gas': transaction.max_fee_per_gas,
+            'max_priority_fee_per_gas': transaction.max_priority_fee_per_gas,
+            'transaction_type': transaction.transaction_type
         }

--- a/cli/polygonetl/streaming/enrich.py
+++ b/cli/polygonetl/streaming/enrich.py
@@ -73,14 +73,18 @@ def enrich_transactions(transactions, receipts):
             'input',
             'block_timestamp',
             'block_number',
-            'block_hash'
+            'block_hash',
+            'max_fee_per_gas',
+            'max_priority_fee_per_gas',
+            'transaction_type'
         ],
         right_fields=[
             ('cumulative_gas_used', 'receipt_cumulative_gas_used'),
             ('gas_used', 'receipt_gas_used'),
             ('contract_address', 'receipt_contract_address'),
             ('root', 'receipt_root'),
-            ('status', 'receipt_status')
+            ('status', 'receipt_status'),
+            ('effective_gas_price', 'effective_gas_price')
         ]))
 
     if len(result) != len(transactions):

--- a/cli/polygonetl/streaming/postgres_tables.py
+++ b/cli/polygonetl/streaming/postgres_tables.py
@@ -46,6 +46,7 @@ BLOCKS = Table(
     Column('gas_limit', BigInteger),
     Column('gas_used', BigInteger),
     Column('transaction_count', BigInteger),
+    Column('base_fee_per_gas', BigInteger),
 )
 
 TRANSACTIONS = Table(
@@ -67,6 +68,10 @@ TRANSACTIONS = Table(
     Column('block_timestamp', TIMESTAMP),
     Column('block_number', BigInteger),
     Column('block_hash', String),
+    Column('max_fee_per_gas', BigInteger),
+    Column('max_priority_fee_per_gas', BigInteger),
+    Column('transaction_type', BigInteger),
+    Column('receipt_effective_gas_price', BigInteger),
 )
 
 LOGS = Table(

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -3,7 +3,7 @@
 ## blocks.csv
 
 | Column            | Type       |
-| ----------------- | ---------- |
+|-------------------|------------|
 | number            | bigint     |
 | hash              | hex_string |
 | parent_hash       | hex_string |
@@ -22,25 +22,29 @@
 | gas_used          | bigint     |
 | timestamp         | bigint     |
 | transaction_count | bigint     |
+| base_fee_per_gas  | bigint     |
 
 ---
 
 ## transactions.csv
 
-| Column            | Type       |
-| ----------------- | ---------- |
-| hash              | hex_string |
-| nonce             | bigint     |
-| block_hash        | hex_string |
-| block_number      | bigint     |
-| transaction_index | bigint     |
-| from_address      | address    |
-| to_address        | address    |
-| value             | numeric    |
-| gas               | bigint     |
-| gas_price         | bigint     |
-| input             | hex_string |
-| block_timestamp   | bigint     |
+| Column                   | Type       |
+|--------------------------|------------|
+| hash                     | hex_string |
+| nonce                    | bigint     |
+| block_hash               | hex_string |
+| block_number             | bigint     |
+| transaction_index        | bigint     |
+| from_address             | address    |
+| to_address               | address    |
+| value                    | numeric    |
+| gas                      | bigint     |
+| gas_price                | bigint     |
+| input                    | hex_string |
+| block_timestamp          | bigint     |
+| max_fee_per_gas          | bigint     |
+| max_priority_fee_per_gas | bigint     |
+| transaction_type         | bigint     |
 
 ---
 
@@ -61,7 +65,7 @@
 ## receipts.csv
 
 | Column              | Type       |
-| ------------------- | ---------- |
+|---------------------|------------|
 | transaction_hash    | hex_string |
 | transaction_index   | bigint     |
 | block_hash          | hex_string |
@@ -71,6 +75,7 @@
 | contract_address    | address    |
 | root                | hex_string |
 | status              | bigint     |
+| effective_gas_price | bigint     |
 
 ---
 


### PR DESCRIPTION
This commit is similar to the EIP-1559 pull request for ethereum-etl: https://github.com/blockchain-etl/ethereum-etl/pull/256
The changes has been tested with `export_blocks_and_transactions` command.

I will create separate pull requests for airflow and dataflow changes.

Fields added:

 - base_fee_per_gas (block) - base fee per gas in protocol, which can move up or down each block according to a formula which is a function of gas used in parent block and gas target (block gas limit divided by elasticity multiplier) of parent block.
 - max_fee_per_gas (tx) - total fee which covers both the priority fee and the block's network fee per gas
 - max_priority_fee_per_gas (tx) - maximum fee per gas tx senders are willing to give to miners to incentivize them to include their transaction
 - transaction_type (tx) - an envelope for future transaction types
 - effective_gas_price (receipt) - a replacement for gasUsed field

**Note:** There is one uncertain change about the postgres table. The file `cli/polygonetl/streaming/postgres_tables.py` is in the repo and I added new fields to it, but I can't find any table schema definition like [this one for Ethereum](https://github.com/blockchain-etl/ethereum-etl-postgres/tree/master/schema). I am wondering if `postgres_tables.py` is even used. Please point me to the schema definition files if they exist, and I will change them accordingly.

