### PR TITLE
Fix Trace Status Calculation

### DIFF
--- a/cli/polygonetl/domain/block.py
+++ b/cli/polygonetl/domain/block.py
@@ -43,3 +43,6 @@ class EthBlock(object):
 
         self.transactions = []
         self.transaction_count = 0
+
+    def __repr__(self):
+        return repr(f"EthBlock number {self.number}, hash {self.hash}")

--- a/cli/polygonetl/domain/block.py
+++ b/cli/polygonetl/domain/block.py
@@ -45,4 +45,4 @@ class EthBlock(object):
         self.transaction_count = 0
 
     def __repr__(self):
-        return repr(f"EthBlock number {self.number}, hash {self.hash}")
+        return f"EthBlock number {self.number}, hash {self.hash}"

--- a/cli/polygonetl/domain/contract.py
+++ b/cli/polygonetl/domain/contract.py
@@ -29,3 +29,8 @@ class EthContract(object):
         self.is_erc20 = False
         self.is_erc721 = False
         self.block_number = None
+
+    def __repr__(self):
+        return repr(
+            f"EthContract block_number {self.block_number}, " f"address {self.address}"
+        )

--- a/cli/polygonetl/domain/contract.py
+++ b/cli/polygonetl/domain/contract.py
@@ -31,6 +31,4 @@ class EthContract(object):
         self.block_number = None
 
     def __repr__(self):
-        return repr(
-            f"EthContract block_number {self.block_number}, " f"address {self.address}"
-        )
+        return f"EthContract block_number {self.block_number}, address {self.address}"

--- a/cli/polygonetl/domain/geth_trace.py
+++ b/cli/polygonetl/domain/geth_trace.py
@@ -27,7 +27,4 @@ class EthGethTrace(object):
         self.transaction_traces = None
 
     def __repr__(self):
-        return repr(
-            f"EthGethTrace block_number {self.block_number}, "
-            f"transaction_traces {self.transaction_traces}"
-        )
+        return f"EthGethTrace block_number {self.block_number}, transaction_traces {self.transaction_traces}"

--- a/cli/polygonetl/domain/geth_trace.py
+++ b/cli/polygonetl/domain/geth_trace.py
@@ -25,3 +25,9 @@ class EthGethTrace(object):
     def __init__(self):
         self.block_number = None
         self.transaction_traces = None
+
+    def __repr__(self):
+        return repr(
+            f"EthGethTrace block_number {self.block_number}, "
+            f"transaction_traces {self.transaction_traces}"
+        )

--- a/cli/polygonetl/domain/receipt.py
+++ b/cli/polygonetl/domain/receipt.py
@@ -33,3 +33,10 @@ class EthReceipt(object):
         self.logs = []
         self.root = None
         self.status = None
+
+    def __repr__(self):
+        return repr(
+            f"EthReceipt block_number {self.block_number}, "
+            f"block_hash {self.block_hash}, "
+            f"transaction_hash {self.transaction_hash}"
+        )

--- a/cli/polygonetl/domain/receipt.py
+++ b/cli/polygonetl/domain/receipt.py
@@ -35,7 +35,7 @@ class EthReceipt(object):
         self.status = None
 
     def __repr__(self):
-        return repr(
+        return (
             f"EthReceipt block_number {self.block_number}, "
             f"block_hash {self.block_hash}, "
             f"transaction_hash {self.transaction_hash}"

--- a/cli/polygonetl/domain/receipt_log.py
+++ b/cli/polygonetl/domain/receipt_log.py
@@ -33,7 +33,7 @@ class EthReceiptLog(object):
         self.topics = []
 
     def __repr__(self):
-        return repr(
+        return (
             f"EthReceiptLog block_number {self.block_number}, "
             f"transaction_hash {self.transaction_hash}, "
             f"log_index {self.log_index}"

--- a/cli/polygonetl/domain/receipt_log.py
+++ b/cli/polygonetl/domain/receipt_log.py
@@ -31,3 +31,10 @@ class EthReceiptLog(object):
         self.address = None
         self.data = None
         self.topics = []
+
+    def __repr__(self):
+        return repr(
+            f"EthReceiptLog block_number {self.block_number}, "
+            f"transaction_hash {self.transaction_hash}, "
+            f"log_index {self.log_index}"
+        )

--- a/cli/polygonetl/domain/token.py
+++ b/cli/polygonetl/domain/token.py
@@ -31,6 +31,4 @@ class EthToken(object):
         self.block_number = None
 
     def __repr__(self):
-        return repr(
-            f"EthToken block_number {self.block_number}, address {self.address}"
-        )
+        return f"EthToken block_number {self.block_number}, address {self.address}"

--- a/cli/polygonetl/domain/token.py
+++ b/cli/polygonetl/domain/token.py
@@ -29,3 +29,8 @@ class EthToken(object):
         self.decimals = None
         self.total_supply = None
         self.block_number = None
+
+    def __repr__(self):
+        return repr(
+            f"EthToken block_number {self.block_number}, address {self.address}"
+        )

--- a/cli/polygonetl/domain/token_transfer.py
+++ b/cli/polygonetl/domain/token_transfer.py
@@ -32,7 +32,7 @@ class EthTokenTransfer(object):
         self.block_number = None
 
     def __repr__(self):
-        return repr(
+        return (
             f"EthTokenTransfer block_number {self.block_number}, "
             f"transaction_hash {self.transaction_hash}, "
             f"log_index {self.log_index}, "

--- a/cli/polygonetl/domain/token_transfer.py
+++ b/cli/polygonetl/domain/token_transfer.py
@@ -30,3 +30,11 @@ class EthTokenTransfer(object):
         self.transaction_hash = None
         self.log_index = None
         self.block_number = None
+
+    def __repr__(self):
+        return repr(
+            f"EthTokenTransfer block_number {self.block_number}, "
+            f"transaction_hash {self.transaction_hash}, "
+            f"log_index {self.log_index}, "
+            f"token {self.token_address}"
+        )

--- a/cli/polygonetl/domain/trace.py
+++ b/cli/polygonetl/domain/trace.py
@@ -43,7 +43,7 @@ class EthTrace(object):
         self.trace_id = None
 
     def __repr__(self):
-        return repr(
+        return (
             f"EthTrace block_number {self.block_number}, "
             f"transaction_hash {self.transaction_hash}, "
             f"transaction_index {self.transaction_index}, "

--- a/cli/polygonetl/domain/trace.py
+++ b/cli/polygonetl/domain/trace.py
@@ -41,3 +41,12 @@ class EthTrace(object):
         self.error = None
         self.status = None
         self.trace_id = None
+
+    def __repr__(self):
+        return repr(
+            f"EthTrace block_number {self.block_number}, "
+            f"transaction_hash {self.transaction_hash}, "
+            f"transaction_index {self.transaction_index}, "
+            f"trace_type {self.trace_type}, "
+            f"status {self.status}"
+        )

--- a/cli/polygonetl/domain/transaction.py
+++ b/cli/polygonetl/domain/transaction.py
@@ -36,7 +36,7 @@ class EthTransaction(object):
         self.input = None
 
     def __repr__(self):
-        return repr(
+        return (
             f"EthTransaction block_number {self.block_number}, "
             f"hash {self.hash}, "
             f"transaction_index {self.transaction_index}"

--- a/cli/polygonetl/domain/transaction.py
+++ b/cli/polygonetl/domain/transaction.py
@@ -34,3 +34,10 @@ class EthTransaction(object):
         self.gas = None
         self.gas_price = None
         self.input = None
+
+    def __repr__(self):
+        return repr(
+            f"EthTransaction block_number {self.block_number}, "
+            f"hash {self.hash}, "
+            f"transaction_index {self.transaction_index}"
+        )

--- a/cli/polygonetl/service/trace_status_calculator.py
+++ b/cli/polygonetl/service/trace_status_calculator.py
@@ -35,7 +35,9 @@ def calculate_trace_statuses(traces):
     grouped_transaction_traces = defaultdict(list)
     for trace in traces:
         if trace.transaction_index is not None:
-            grouped_transaction_traces[trace.transaction_index].append(trace)
+            grouped_transaction_traces[
+                f"{trace.block_number}_{trace.transaction_index}"
+            ].append(trace)
 
     # calculate statuses for each transaction
     for transaction_traces in grouped_transaction_traces.values():
@@ -57,6 +59,14 @@ def calculate_trace_statuses_for_single_transaction(all_traces):
             if parent_trace is None:
                 raise ValueError('A parent trace for trace with trace_address {} in transaction {} is not found'
                                  .format(trace.trace_address, trace.transaction_index))
+
+            if parent_trace.block_number != trace.block_number:
+                raise ValueError(
+                    f"Parent trace is from a different block. \n"
+                    f"Parent trace: {parent_trace}, \n"
+                    f"Trace: {trace}"
+                )
+
             if parent_trace.status == 0:
                 trace.status = 0
 


### PR DESCRIPTION
# What?
Status for some traces were being incorrectly calculated, causing there to be missing contracts in the contracts table.

# Why?
The function [calculate_trace_statuses_for_single_transaction](https://github.com/blockchain-etl/polygon-etl/blob/main/cli/polygonetl/service/trace_status_calculator.py#L47) was designed to only process a single transaction at a time but was instead processing transactions from multiple blocks due to it being [grouped by](https://github.com/blockchain-etl/polygon-etl/blob/main/cli/polygonetl/service/trace_status_calculator.py#L38) `transaction_index` rather than `block_number` + `transaction_index`.

# How?
Update code to group by `block_number` + `transaction_index`.