### PR TITLE
Upgrade to composer 2

### DIFF
--- a/.github/workflows/airflow-tests.yml
+++ b/.github/workflows/airflow-tests.yml
@@ -1,10 +1,10 @@
 name: airflowTests
 
-on: workflow_dispatch
-#   pull_request:
-#     branches: [main]
-#   push:
-#     branches: [main]
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
 
 jobs:
   test:

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,25 +1,23 @@
 # Expected context is repository root
 # This makes cli folder is accessible for copy and install
-# docker build -f . -t polygon-etl-airflow-tests ..
+# docker build -f ./Dockerfile -t polygon-etl-tests ..
 
 FROM python:3.8.12
 
-WORKDIR /airflow
+WORKDIR /app
 
-COPY requirements_test.txt requirements_test.txt
-COPY airflow/requirements_local.txt requirements_local.txt
-COPY airflow/requirements_airflow.txt requirements_airflow.txt
+RUN pip install --upgrade pip
+
+COPY pytest.ini requirements_test.txt airflow/requirements* .
 
 RUN pip install \
-    --upgrade pip \
     -r requirements_test.txt \
     -r requirements_local.txt
 
-COPY cli ../cli
+COPY cli cli
 RUN pip install \
-    -e ../cli \
+    -e cli \
     -r requirements_airflow.txt
 
-COPY airflow/tests tests
-COPY airflow/dags dags
+COPY airflow airflow
 ENTRYPOINT pytest -vv

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -29,9 +29,31 @@ Airflow DAGs for exporting and loading the Polygon blockchain data to Google Big
 
    ```bash
    ENVIRONMENT_NAME=${PROJECT}-${ENVIRONMENT_INDEX} && echo "Environment name is ${ENVIRONMENT_NAME}"
-   gcloud composer environments create ${ENVIRONMENT_NAME} --location=us-central1 --zone=us-central1-a \
-       --disk-size=30GB --machine-type=n1-standard-1 --node-count=3 --python-version=3 --image-version=composer-1.10.6-airflow-1.10.3 \
-       --network=default --subnetwork=default
+
+   AIRFLOW_CONFIGS_ARR=(
+     "celery-worker_concurrency=16"
+     "webserver-instance_name=${ENVIRONMENT_NAME}"
+   )
+   AIRFLOW_CONFIGS=$(IFS=, ; echo "${AIRFLOW_CONFIGS_ARR[*]}")
+
+   gcloud composer environments create \
+     ${ENVIRONMENT_NAME} \
+     --location=us-central1 \
+     --image-version=composer-2.0.28-airflow-2.2.5 \
+     --environment-size=small \
+     --scheduler-cpu=2 \
+     --scheduler-memory=4 \
+     --scheduler-storage=1 \
+     --scheduler-count=1 \
+     --web-server-cpu=1 \
+     --web-server-memory=2 \
+     --web-server-storage=512MB \
+     --worker-cpu=2 \
+     --worker-memory=13 \
+     --worker-storage=1 \
+     --min-workers=1 \
+     --max-workers=4 \
+     --airflow-configs=${AIRFLOW_CONFIGS}
 
    gcloud composer environments update $ENVIRONMENT_NAME --location=us-central1 --update-pypi-packages-from-file=requirements_airflow.txt
    ```

--- a/airflow/dags/polygon_parse_dag.py
+++ b/airflow/dags/polygon_parse_dag.py
@@ -24,9 +24,10 @@ for folder in glob(table_definitions_folder):
     globals()[dag_id] = build_parse_dag(
         dag_id=dag_id,
         dataset_folder=folder,
+        source_dataset_name="crypto_polygon",
         **read_parse_dag_vars(
             var_prefix=var_prefix,
             dataset=dataset,
-            schedule_interval='30 7 * * *'
+            parse_schedule_interval='30 7 * * *'
         )
     )

--- a/airflow/dags/polygon_partition_dag.py
+++ b/airflow/dags/polygon_partition_dag.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import logging
 
 from polygonetl_airflow.build_partition_dag import build_partition_dag
+from polygonetl_airflow.variables import read_partition_dag_vars
 
 logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
@@ -10,10 +11,11 @@ logging.getLogger().setLevel(logging.DEBUG)
 # airflow DAG
 DAG = build_partition_dag(
     dag_id='polygon_partition_dag',
-    partitioned_project_id='blockchain-etl-internal',
-    partitioned_dataset_name = 'crypto_polygon_partitioned',
-    public_project_id = 'public-data-finance',
-    public_dataset_name = 'crypto_polygon',
     load_dag_id='polygon_load_dag',
-    schedule_interval='0 7 * * *',
+    partitioned_dataset_name = 'crypto_polygon_partitioned',
+    public_dataset_name = 'crypto_polygon',
+    **read_partition_dag_vars(
+        var_prefix="polygon_",
+        partition_schedule_interval="0 7 * * *",
+    ),
 )

--- a/airflow/dags/polygonetl_airflow/build_export_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_export_dag.py
@@ -71,8 +71,8 @@ def build_export_dag(
         max_active_runs=export_max_active_runs
     )
 
-    from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
-    cloud_storage_hook = GoogleCloudStorageHook(google_cloud_storage_conn_id="google_cloud_default")
+    from airflow.providers.google.cloud.hooks.gcs import GCSHook
+    cloud_storage_hook = GCSHook(gcp_conn_id="google_cloud_default")
 
     # Export
     def export_path(directory, date):

--- a/airflow/dags/polygonetl_airflow/build_export_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_export_dag.py
@@ -110,9 +110,9 @@ def build_export_dag(
 
         return int(start_block), int(end_block)
 
-    def export_blocks_and_transactions_command(execution_date, provider_uri, **kwargs):
+    def export_blocks_and_transactions_command(logical_date, provider_uri, **kwargs):
         with TemporaryDirectory() as tempdir:
-            start_block, end_block = get_block_range(tempdir, execution_date, provider_uri)
+            start_block, end_block = get_block_range(tempdir, logical_date, provider_uri)
 
             logging.info('Calling export_blocks_and_transactions({}, {}, {}, {}, {}, ...)'.format(
                 start_block, end_block, export_batch_size, provider_uri, export_max_workers))
@@ -128,21 +128,21 @@ def build_export_dag(
             )
 
             copy_to_export_path(
-                os.path.join(tempdir, "blocks_meta.txt"), export_path("blocks_meta", execution_date)
+                os.path.join(tempdir, "blocks_meta.txt"), export_path("blocks_meta", logical_date)
             )
 
             copy_to_export_path(
-                os.path.join(tempdir, "blocks.csv"), export_path("blocks", execution_date)
+                os.path.join(tempdir, "blocks.csv"), export_path("blocks", logical_date)
             )
 
             copy_to_export_path(
-                os.path.join(tempdir, "transactions.csv"), export_path("transactions", execution_date)
+                os.path.join(tempdir, "transactions.csv"), export_path("transactions", logical_date)
             )
 
-    def export_receipts_and_logs_command(execution_date, provider_uri, **kwargs):
+    def export_receipts_and_logs_command(logical_date, provider_uri, **kwargs):
         with TemporaryDirectory() as tempdir:
             copy_from_export_path(
-                export_path("transactions", execution_date), os.path.join(tempdir, "transactions.csv")
+                export_path("transactions", logical_date), os.path.join(tempdir, "transactions.csv")
             )
 
             logging.info('Calling extract_csv_column(...)')
@@ -164,14 +164,14 @@ def build_export_dag(
             )
 
             copy_to_export_path(
-                os.path.join(tempdir, "receipts.csv"), export_path("receipts", execution_date)
+                os.path.join(tempdir, "receipts.csv"), export_path("receipts", logical_date)
             )
-            copy_to_export_path(os.path.join(tempdir, "logs.json"), export_path("logs", execution_date))
+            copy_to_export_path(os.path.join(tempdir, "logs.json"), export_path("logs", logical_date))
 
-    def extract_contracts_command(execution_date, **kwargs):
+    def extract_contracts_command(logical_date, **kwargs):
         with TemporaryDirectory() as tempdir:
             copy_from_export_path(
-                export_path("traces", execution_date), os.path.join(tempdir, "traces.csv")
+                export_path("traces", logical_date), os.path.join(tempdir, "traces.csv")
             )
 
             logging.info('Calling extract_contracts(..., {}, {})'.format(
@@ -185,13 +185,13 @@ def build_export_dag(
             )
 
             copy_to_export_path(
-                os.path.join(tempdir, "contracts.json"), export_path("contracts", execution_date)
+                os.path.join(tempdir, "contracts.json"), export_path("contracts", logical_date)
             )
 
-    def extract_tokens_command(execution_date, provider_uri, **kwargs):
+    def extract_tokens_command(logical_date, provider_uri, **kwargs):
         with TemporaryDirectory() as tempdir:
             copy_from_export_path(
-                export_path("contracts", execution_date), os.path.join(tempdir, "contracts.json")
+                export_path("contracts", logical_date), os.path.join(tempdir, "contracts.json")
             )
 
             logging.info('Calling extract_tokens(..., {}, {})'.format(export_max_workers, provider_uri))
@@ -203,13 +203,13 @@ def build_export_dag(
             )
 
             copy_to_export_path(
-                os.path.join(tempdir, "tokens.csv"), export_path("tokens", execution_date)
+                os.path.join(tempdir, "tokens.csv"), export_path("tokens", logical_date)
             )
 
-    def extract_token_transfers_command(execution_date, **kwargs):
+    def extract_token_transfers_command(logical_date, **kwargs):
         with TemporaryDirectory() as tempdir:
             copy_from_export_path(
-                export_path("logs", execution_date), os.path.join(tempdir, "logs.json")
+                export_path("logs", logical_date), os.path.join(tempdir, "logs.json")
             )
 
             logging.info('Calling extract_token_transfers(..., {}, ..., {})'.format(
@@ -224,12 +224,12 @@ def build_export_dag(
 
             copy_to_export_path(
                 os.path.join(tempdir, "token_transfers.csv"),
-                export_path("token_transfers", execution_date),
+                export_path("token_transfers", logical_date),
             )
 
-    def export_traces_command(execution_date, provider_uri, **kwargs):
+    def export_traces_command(logical_date, provider_uri, **kwargs):
         with TemporaryDirectory() as tempdir:
-            start_block, end_block = get_block_range(tempdir, execution_date, provider_uri)
+            start_block, end_block = get_block_range(tempdir, logical_date, provider_uri)
             if start_block == 0:
                 start_block = 1
 
@@ -249,11 +249,11 @@ def build_export_dag(
                     provider_uri=provider_uri
                 )
                 copy_to_export_path(
-                    os.path.join(tempdir, "geth_traces.json"), export_path("traces", execution_date)
+                    os.path.join(tempdir, "geth_traces.json"), export_path("traces", logical_date)
                 )
             else:
                 copy_from_export_path(
-                   export_path("traces", execution_date), os.path.join(tempdir, "geth_traces.json"), 
+                   export_path("traces", logical_date), os.path.join(tempdir, "geth_traces.json"), 
                 )
 
             extract_geth_traces.callback(
@@ -263,7 +263,7 @@ def build_export_dag(
             )
 
             copy_to_export_path(
-                os.path.join(tempdir, "traces.csv"), export_path("traces", execution_date)
+                os.path.join(tempdir, "traces.csv"), export_path("traces", logical_date)
             )
 
     def add_export_task(toggle, task_id, python_callable, dependencies=None):

--- a/airflow/dags/polygonetl_airflow/build_export_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_export_dag.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from tempfile import TemporaryDirectory
 
 from airflow import DAG, configuration
-from airflow.operators import python_operator
+from airflow.operators.python import PythonOperator
 
 from polygonetl.cli import (
     get_block_range_for_date,
@@ -268,10 +268,9 @@ def build_export_dag(
 
     def add_export_task(toggle, task_id, python_callable, dependencies=None):
         if toggle:
-            operator = python_operator.PythonOperator(
+            operator = PythonOperator(
                 task_id=task_id,
                 python_callable=python_callable,
-                provide_context=True,
                 execution_timeout=timedelta(hours=24),
                 dag=dag,
             )

--- a/airflow/dags/polygonetl_airflow/build_export_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_export_dag.py
@@ -20,7 +20,7 @@ from polygonetl.cli import (
     export_geth_traces,
     extract_geth_traces
 )
-
+from polygonetl_airflow.gcs_utils import download_from_gcs, upload_to_gcs
 from utils.error_handling import handle_dag_failure
 
 # Use Composer's suggested Data folder for temp storage
@@ -351,59 +351,3 @@ def add_provider_uri_fallback_loop(python_callable, provider_uris):
                     raise e
 
     return python_callable_with_fallback
-
-
-MEGABYTE = 1024 * 1024
-
-
-# Helps avoid OverflowError: https://stackoverflow.com/questions/47610283/cant-upload-2gb-to-google-cloud-storage
-# https://developers.google.com/api-client-library/python/guide/media_upload#resumable-media-chunked-upload
-def upload_to_gcs(gcs_hook, bucket, object, filename, mime_type='application/octet-stream'):
-    from apiclient.http import MediaFileUpload
-    from googleapiclient import errors
-
-    service = gcs_hook.get_conn()
-
-    if os.path.getsize(filename) > 10 * MEGABYTE:
-        media = MediaFileUpload(filename, mime_type, resumable=True)
-
-        try:
-            request = service.objects().insert(bucket=bucket, name=object, media_body=media)
-            response = None
-            while response is None:
-                status, response = request.next_chunk()
-                if status:
-                    logging.info("Uploaded %d%%." % int(status.progress() * 100))
-
-            return True
-        except errors.HttpError as ex:
-            if ex.resp['status'] == '404':
-                return False
-            raise
-    else:
-        media = MediaFileUpload(filename, mime_type)
-
-        try:
-            service.objects().insert(bucket=bucket, name=object, media_body=media).execute()
-            return True
-        except errors.HttpError as ex:
-            if ex.resp['status'] == '404':
-                return False
-            raise
-
-
-# Can download big files unlike gcs_hook.download which saves files in memory first
-def download_from_gcs(bucket, object, filename):
-    from google.cloud import storage
-
-    storage_client = storage.Client()
-
-    bucket = storage_client.get_bucket(bucket)
-    blob_meta = bucket.get_blob(object)
-
-    if blob_meta.size > 10 * MEGABYTE:
-        blob = bucket.blob(object, chunk_size=10 * MEGABYTE)
-    else:
-        blob = bucket.blob(object)
-
-    blob.download_to_filename(filename)

--- a/airflow/dags/polygonetl_airflow/build_load_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_load_dag.py
@@ -246,11 +246,11 @@ def build_load_dag(
         return verify_task
 
     def add_save_checkpoint_tasks(dependencies=None):
-        def save_checkpoint(execution_date, **kwargs):
+        def save_checkpoint(logical_date, **kwargs):
             with TemporaryDirectory() as tempdir:
                 local_path = os.path.join(tempdir, "checkpoint.txt")
                 remote_path = "load/checkpoint/block_date={block_date}/checkpoint.txt".format(
-                    block_date=execution_date.strftime("%Y-%m-%d")
+                    block_date=logical_date.strftime("%Y-%m-%d")
                 )
                 open(local_path, mode='a').close()
                 upload_to_gcs(

--- a/airflow/dags/polygonetl_airflow/build_load_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_load_dag.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 from tempfile import TemporaryDirectory
 
 from airflow import models
-from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
 from airflow.providers.google.cloud.sensors.gcs import GCSObjectExistenceSensor
 from airflow.operators.python import PythonOperator
@@ -252,10 +252,11 @@ def build_load_dag(
                 )
                 open(local_path, mode='a').close()
                 upload_to_gcs(
-                    gcs_hook=GoogleCloudStorageHook(google_cloud_storage_conn_id="google_cloud_default"),
+                    gcs_hook=GCSHook(gcp_conn_id="google_cloud_default"),
                     bucket=checkpoint_bucket,
                     object=remote_path,
-                    filename=local_path)
+                    filename=local_path,
+                )
 
         save_checkpoint_task = PythonOperator(
             task_id='save_checkpoint',

--- a/airflow/dags/polygonetl_airflow/build_load_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_load_dag.py
@@ -172,7 +172,7 @@ def build_load_dag(
 
             sql_path = os.path.join(dags_folder, 'resources/stages/enrich/sqls/{task}.sql'.format(task=task))
             sql_template = read_file(sql_path)
-            sql = kwargs['task'].render_template('', sql_template, template_context)
+            sql = kwargs['task'].render_template(sql_template, template_context)
             print('Enrichment sql:')
             print(sql)
 
@@ -204,7 +204,7 @@ def build_load_dag(
                 merge_template_context['params']['source_table'] = temp_table_name
                 merge_template_context['params']['destination_dataset_project_id'] = destination_dataset_project_id
                 merge_template_context['params']['destination_dataset_name'] = dataset_name
-                merge_sql = kwargs['task'].render_template('', merge_sql_template, merge_template_context)
+                merge_sql = kwargs['task'].render_template(merge_sql_template, merge_template_context)
                 print('Merge sql:')
                 print(merge_sql)
                 merge_job = client.query(merge_sql, location='US', job_config=merge_job_config)

--- a/airflow/dags/polygonetl_airflow/build_load_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_load_dag.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryDirectory
 from airflow import models
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
-from airflow.contrib.sensors.gcs_sensor import GoogleCloudStorageObjectSensor
+from airflow.providers.google.cloud.sensors.gcs import GCSObjectExistenceSensor
 from airflow.operators.python import PythonOperator
 from google.cloud import bigquery
 from google.cloud.bigquery import TimePartitioning
@@ -96,7 +96,7 @@ def build_load_dag(
     dags_folder = os.environ.get('DAGS_FOLDER', '/home/airflow/gcs/dags')
 
     def add_load_tasks(task, file_format, allow_quoted_newlines=False):
-        wait_sensor = GoogleCloudStorageObjectSensor(
+        wait_sensor = GCSObjectExistenceSensor(
             task_id='wait_latest_{task}'.format(task=task),
             timeout=12 * 60 * 60,
             poke_interval=60,

--- a/airflow/dags/polygonetl_airflow/build_load_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_load_dag.py
@@ -11,7 +11,6 @@ from airflow import models
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.contrib.operators.bigquery_operator import BigQueryOperator
 from airflow.contrib.sensors.gcs_sensor import GoogleCloudStorageObjectSensor
-from airflow.operators.email_operator import EmailOperator
 from airflow.operators.python_operator import PythonOperator
 from google.cloud import bigquery
 from google.cloud.bigquery import TimePartitioning

--- a/airflow/dags/polygonetl_airflow/build_load_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_load_dag.py
@@ -11,7 +11,7 @@ from airflow import models
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.contrib.operators.bigquery_operator import BigQueryOperator
 from airflow.contrib.sensors.gcs_sensor import GoogleCloudStorageObjectSensor
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from google.cloud import bigquery
 from google.cloud.bigquery import TimePartitioning
 
@@ -217,7 +217,6 @@ def build_load_dag(
         enrich_operator = PythonOperator(
             task_id='enrich_{task}'.format(task=task),
             python_callable=enrich_task,
-            provide_context=True,
             execution_timeout=timedelta(minutes=60),
             dag=dag
         )
@@ -261,7 +260,6 @@ def build_load_dag(
         save_checkpoint_task = PythonOperator(
             task_id='save_checkpoint',
             python_callable=save_checkpoint,
-            provide_context=True,
             execution_timeout=timedelta(hours=1),
             dag=dag,
         )

--- a/airflow/dags/polygonetl_airflow/build_parse_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_parse_dag.py
@@ -8,7 +8,7 @@ from glob import glob
 
 from airflow import models
 from airflow.operators.bash import BashOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.operators.sensors import ExternalTaskSensor
 from google.cloud import bigquery
 
@@ -78,7 +78,6 @@ def build_parse_dag(
         validation_error_operator = PythonOperator(
             task_id='validation_error',
             python_callable=raise_validation_error,
-            provide_context=True,
             execution_timeout=timedelta(minutes=10),
             dag=dag
         )
@@ -105,7 +104,6 @@ def build_parse_dag(
         parsing_operator = PythonOperator(
             task_id=table_name,
             python_callable=parse_task,
-            provide_context=True,
             execution_timeout=timedelta(minutes=60),
             dag=dag
         )
@@ -131,7 +129,6 @@ def build_parse_dag(
         create_view_operator = PythonOperator(
             task_id=f'create_view_{view_name}',
             python_callable=create_view_task,
-            provide_context=True,
             execution_timeout=timedelta(minutes=10),
             dag=dag
         )
@@ -155,7 +152,6 @@ def build_parse_dag(
         return PythonOperator(
             task_id="share_dataset",
             python_callable=share_dataset_task,
-            provide_context=True,
             execution_timeout=timedelta(minutes=10),
             dag=dag,
         )

--- a/airflow/dags/polygonetl_airflow/build_parse_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_parse_dag.py
@@ -28,9 +28,12 @@ def build_parse_dag(
         dag_id,
         dataset_folder,
         parse_destination_dataset_project_id,
+        source_project_id,
+        source_dataset_name,
+        internal_project_id,
         notification_emails=None,
         parse_start_date=datetime(2020, 5, 30),
-        schedule_interval='0 0 * * *',
+        parse_schedule_interval='0 0 * * *',
         parse_all_partitions=None,
 ):
 
@@ -38,10 +41,6 @@ def build_parse_dag(
 
     if parse_all_partitions:
         dag_id = dag_id + '_FULL'
-
-
-    SOURCE_PROJECT_ID = 'public-data-finance'
-    SOURCE_DATASET_NAME = 'crypto_polygon'
 
     PARTITION_DAG_ID = 'polygon_partition_dag'
 
@@ -61,7 +60,7 @@ def build_parse_dag(
     dag = models.DAG(
         dag_id,
         catchup=False,
-        schedule_interval=schedule_interval,
+        schedule_interval=parse_schedule_interval,
         default_args=default_dag_args)
 
     validation_error = None
@@ -93,9 +92,10 @@ def build_parse_dag(
                 bigquery_client=client,
                 table_definition=table_definition,
                 ds=ds,
-                source_project_id=SOURCE_PROJECT_ID,
-                source_dataset_name=SOURCE_DATASET_NAME,
+                source_project_id=source_project_id,
+                source_dataset_name=source_dataset_name,
                 destination_project_id=parse_destination_dataset_project_id,
+                internal_project_id=internal_project_id,
                 sqls_folder=os.path.join(dags_folder, 'resources/stages/parse/sqls'),
                 parse_all_partitions=parse_all_partitions
             )

--- a/airflow/dags/polygonetl_airflow/build_parse_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_parse_dag.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from glob import glob
 
 from airflow import models
-from airflow.operators.bash_operator import BashOperator
+from airflow.operators.bash import BashOperator
 from airflow.operators.email_operator import EmailOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.sensors import ExternalTaskSensor

--- a/airflow/dags/polygonetl_airflow/build_parse_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_parse_dag.py
@@ -9,7 +9,7 @@ from glob import glob
 from airflow import models
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
-from airflow.operators.sensors import ExternalTaskSensor
+from airflow.sensors.external_task import ExternalTaskSensor
 from google.cloud import bigquery
 
 from polygonetl_airflow.bigquery_utils import create_view, share_dataset_all_users_read

--- a/airflow/dags/polygonetl_airflow/build_parse_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_parse_dag.py
@@ -8,7 +8,6 @@ from glob import glob
 
 from airflow import models
 from airflow.operators.bash import BashOperator
-from airflow.operators.email_operator import EmailOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.sensors import ExternalTaskSensor
 from google.cloud import bigquery

--- a/airflow/dags/polygonetl_airflow/build_partition_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_partition_dag.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from airflow import models
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
-from airflow.operators.sensors import ExternalTaskSensor
+from airflow.sensors.external_task import ExternalTaskSensor
 from google.cloud import bigquery
 
 from utils.error_handling import handle_dag_failure

--- a/airflow/dags/polygonetl_airflow/build_partition_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_partition_dag.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime, timedelta
 
 from airflow import models
-from airflow.operators.bash_operator import BashOperator
+from airflow.operators.bash import BashOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.sensors import ExternalTaskSensor
 from google.cloud import bigquery

--- a/airflow/dags/polygonetl_airflow/build_partition_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_partition_dag.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 
 from airflow import models
 from airflow.operators.bash import BashOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.operators.sensors import ExternalTaskSensor
 from google.cloud import bigquery
 
@@ -67,7 +67,6 @@ def build_partition_dag(
         extract_operator = PythonOperator(
             task_id=f'partition_{task}',
             python_callable=enrich_task,
-            provide_context=True,
             execution_timeout=timedelta(minutes=60),
             dag=dag
         )

--- a/airflow/dags/polygonetl_airflow/build_partition_dag.py
+++ b/airflow/dags/polygonetl_airflow/build_partition_dag.py
@@ -22,13 +22,14 @@ def build_partition_dag(
         public_project_id,
         public_dataset_name,
         load_dag_id,
+        partition_start_date=datetime(2015, 7, 30),
+        partition_schedule_interval='0 0 * * *',
         notification_emails=None,
-        schedule_interval='0 0 * * *'
 ):
 
     default_dag_args = {
         'depends_on_past': False,
-        'start_date': datetime.strptime('2015-07-30', '%Y-%m-%d'),
+        'start_date': partition_start_date,
         'email_on_failure': True,
         'email_on_retry': False,
         'retries': 5,
@@ -43,7 +44,7 @@ def build_partition_dag(
     dag = models.DAG(
         dag_id,
         catchup=False,
-        schedule_interval=schedule_interval,
+        schedule_interval=partition_schedule_interval,
         default_args=default_dag_args)
 
     def add_partition_tasks(task, sql_template, dependencies=None):

--- a/airflow/dags/polygonetl_airflow/parse/parse_logic.py
+++ b/airflow/dags/polygonetl_airflow/parse/parse_logic.py
@@ -23,14 +23,15 @@ def parse(
         source_project_id,
         source_dataset_name,
         destination_project_id,
+        internal_project_id,
         sqls_folder,
         parse_all_partitions,
         time_func=time.time
 ):
 
     # Refer to this issue for more detail https://github.com/blockchain-etl/ethereum-etl-airflow/issues/80.
-
-    internal_project_id = destination_project_id + '-internal'
+    if internal_project_id is None:
+        internal_project_id = destination_project_id + '-internal'
     dataset_name = 'polygon_' + table_definition['table']['dataset_name']
 
     create_or_replace_internal_view(

--- a/airflow/dags/polygonetl_airflow/variables.py
+++ b/airflow/dags/polygonetl_airflow/variables.py
@@ -59,16 +59,44 @@ def read_load_dag_vars(var_prefix, **kwargs):
 
     return vars
 
+
+def read_partition_dag_vars(var_prefix, **kwargs):
+    vars = {
+        # public_project_id arg takes its value from destination_dataset_project_id
+        "public_project_id": read_var(
+            "destination_dataset_project_id", var_prefix, True, **kwargs
+        ),
+        "partitioned_project_id": read_var(
+            "partitioned_project_id", var_prefix, True, **kwargs
+        ),
+        "partition_schedule_interval": read_var(
+            "partition_schedule_interval", var_prefix, False, **kwargs
+        ),
+        "notification_emails": read_var("notification_emails", None, False, **kwargs),
+    }
+
+    partition_start_date = read_var("partition_start_date", var_prefix, False, **kwargs)
+    if partition_start_date is not None:
+        partition_start_date = datetime.strptime(partition_start_date, "%Y-%m-%d")
+        vars["partition_start_date"] = partition_start_date
+
+    return vars
+
+
 def read_parse_dag_vars(var_prefix, dataset, **kwargs):
     per_dataset_var_prefix = var_prefix + dataset + '_'
     vars = {
+        # source_project_id takes its value from destination_dataset_project_id
+        'source_project_id': read_var('destination_dataset_project_id', var_prefix, True, **kwargs),
+        # internal_project_id takes its value from partitioned_project_id
+        'internal_project_id': read_var('partitioned_project_id', var_prefix, True, **kwargs),
         'parse_destination_dataset_project_id': read_var('parse_destination_dataset_project_id', var_prefix, True, **kwargs),
-        'schedule_interval': read_var('schedule_interval', var_prefix, True, **kwargs),
+        'parse_schedule_interval': read_var('parse_schedule_interval', var_prefix, True, **kwargs),
         'parse_all_partitions': parse_bool(read_var('parse_all_partitions', per_dataset_var_prefix, False), default=None),
         'notification_emails': read_var('notification_emails', None, False, **kwargs),
     }
 
-    parse_start_date = read_var('parse_start_date', vars, False, **kwargs)
+    parse_start_date = read_var('parse_start_date', var_prefix, False, **kwargs)
     if parse_start_date is not None:
         parse_start_date = datetime.strptime(parse_start_date, '%Y-%m-%d')
         vars['parse_start_date'] = parse_start_date

--- a/airflow/requirements_airflow.txt
+++ b/airflow/requirements_airflow.txt
@@ -3,4 +3,5 @@
 # pip will then prioritise the local polygon-etl package over pypi
 
 discord-webhook==0.14.0
+eth-rlp==0.2.1             # Fixes install conflicts issue in Composer
 polygon-etl==0.2.1

--- a/airflow/requirements_local.txt
+++ b/airflow/requirements_local.txt
@@ -1,10 +1,5 @@
-# Intended to match `composer-1.10.6-airflow-1.10.3` packages closely
-# https://cloud.google.com/composer/docs/concepts/versioning/composer-versions#images
-
-apache-airflow==1.10.3
-Flask==1.0.4
-google-api-python-client==1.7.8
-google-cloud-bigquery==1.10.1
-google-cloud-storage==1.13.2
-pandas==0.25.1
-pandas-gbq==0.9.0
+apache-airflow[google]==2.2.5       # similar to `composer-2.0.28-airflow-2.2.5`
+Flask==1.1.2                        # matches `composer-2.0.28-airflow-2.2.5`
+google-api-core==2.8.2              # matches `composer-2.0.28-airflow-2.2.5`
+google-cloud-bigquery==2.34.4       # matches `composer-2.0.28-airflow-2.2.5`
+google-cloud-storage==1.44.0        # matches `composer-2.0.28-airflow-2.2.5`

--- a/airflow/test_dags/dummy_dag.py
+++ b/airflow/test_dags/dummy_dag.py
@@ -5,7 +5,7 @@ In order to test this DAG, put it directly in the `dags` folder in the destinati
 from datetime import datetime, timedelta
 
 from airflow import models
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 
 from utils.error_handling import handle_dag_failure
 

--- a/airflow/tests/test_dag_validation.py
+++ b/airflow/tests/test_dag_validation.py
@@ -20,17 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import sys
 from pathlib import Path
 
 import pytest
 from airflow.models import DagBag, Variable
 
 DAGS_FOLDER = f"{Path(__file__).resolve().parent.parent}/dags"
-
-# Add to PATH to fix relative imports, like Airflow running dynamically
-# https://airflow.apache.org/docs/apache-airflow/stable/modules_management.html#built-in-pythonpath-entries-in-airflow
-sys.path.append(DAGS_FOLDER)
 
 MOCK_ENV_VARS = {
     "AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT": "google-cloud-platform://",
@@ -73,23 +68,3 @@ def dag_bag(monkeypatch):
 
 def test_no_import_errors(dag_bag):
     assert len(dag_bag.import_errors) == 0, "No Import Failures"
-
-
-def test_dag_ids(dag_bag):
-    expected_dag_ids = [
-        "polygon_export_dag",
-        "polygon_load_dag",
-        "polygon_parse_balancer_dag",
-        "polygon_parse_common_dag",
-        "polygon_parse_dfyn_dag",
-        "polygon_parse_instadapp_dag",
-        "polygon_parse_opensea_dag",
-        "polygon_parse_polygon_dag",
-        "polygon_parse_quickswap_dag",
-        "polygon_parse_seaport_dag",
-        "polygon_parse_sushiswap_dag",
-        "polygon_parse_uniswap_dag",
-        "polygon_partition_dag",
-        "polygon_verify_streaming_dag",
-    ]
-    assert sorted(dag_bag.dag_ids) == expected_dag_ids

--- a/airflow/tests/test_dag_validation.py
+++ b/airflow/tests/test_dag_validation.py
@@ -49,6 +49,7 @@ MOCK_AIRFLOW_VARS = {
     "polygon_max_lag_in_minutes": "30",
     "polygon_output_bucket": "test_polygon_output_bucket",
     "polygon_parse_destination_dataset_project_id": "test_polygon_parse_destination_dataset_project_id",
+    "polygon_partitioned_project_id": "test_polygon_partitioned_project_id",
     "polygon_provider_uris": "test_polygon_provider_uri_0, test_polygon_provider_uri_1",
     "polygon_provider_uris_archival": "test_polygon_provider_uri_archival",
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath =
+    airflow/dags


### PR DESCRIPTION
### What
Migration of polygon-etl to composer 2 environment (airflow 2.2.5)

### Why
Composer1 will be deprecated next year

### How
- [x] Update and re-enable local and GitHub workflow Airflow tests
- [x] Update requirements_local.txt
- [x] Resolve pip conflicts in Composer and update requirements_airflow.txt
- [x] Jinja macros (execution_date -> logical_date)
- [x] Operators, hooks, sensors
- [x] Fix local storage limits by moving to GCS Fuse
- [x] Use improved GCS api to simplify upload/download
- [x] Update docs

### Testing
- [x] Built dev environment ([Composer](https://console.cloud.google.com/composer/environments/detail/us-central1/polygon-etl-dev-0) / [Airflow UI](https://0ccaba36c58445c98866c3fd313a9cb9-dot-us-central1.composer.googleusercontent.com/home))
- [x] Run dags successfully
- [x] Checked data quality
  - [x] 2022-10-10 -> 2022-10-16
    - [x] export/load, full diff'd all tables in `crypto_polygon`
    - [x] partition, full diff'd all tables in `crypto_polygon_partitioned`
    - [x] parse, full diff'd all tables in `polygon_dfyn` and `polygon_instadapp`

### Deployment
- [x] Built prod environment ([Composer](https://console.cloud.google.com/composer/environments/detail/us-central1/polygon-etl-1) / [Airflow UI](https://bf9ea76e4b7c4e549e48288dae61ad0b-dot-us-central1.composer.googleusercontent.com/home))
- [x] Disable dags in old env, enable in new

### Related PRs
- https://github.com/blockchain-etl/polygon-etl/pull/91