### PR TITLE
Fix dependencies

### DIFF
--- a/airflow/requirements_airflow.txt
+++ b/airflow/requirements_airflow.txt
@@ -5,4 +5,4 @@
 discord-webhook==0.14.0
 eth-rlp==0.2.1             # Fixes install conflicts issue in Composer
 eth-utils==1.8.4           # Fixes install conflicts issue in Composer
-polygon-etl==0.2.1
+polygon-etl==0.2.2

--- a/airflow/requirements_airflow.txt
+++ b/airflow/requirements_airflow.txt
@@ -4,4 +4,5 @@
 
 discord-webhook==0.14.0
 eth-rlp==0.2.1             # Fixes install conflicts issue in Composer
+eth-utils==1.8.4           # Fixes install conflicts issue in Composer
 polygon-etl==0.2.1

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -11,7 +11,7 @@ long_description = read("README.md") if os.path.isfile("README.md") else ""
 
 setup(
     name="polygon-etl",
-    version="0.2.1",
+    version="0.2.2",
     author="Evgeny Medvedev",
     author_email="evge.medvedev@gmail.com",
     description="Tools for exporting Polygon blockchain data to CSV or JSON",

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -46,6 +46,7 @@ setup(
     extras_require={
         "streaming": [
             "google-cloud-pubsub==2.1.0",
+            "pytz",  # See https://github.com/googleapis/python-pubsub/issues/468
             "google-cloud-storage==1.33.0",
             "pg8000==1.13.2",
             "sqlalchemy==1.3.13",


### PR DESCRIPTION
Seems `pytz` is required for `google-cloud-pubsub==2.1.0` (see https://github.com/googleapis/python-pubsub/issues/468). And `eth-utils` needs to be pinned explicitly for Composer (tested with `composer-2.0.28-airflow-2.2.5`).