### PR TITLE
Adding Stable and Variable DebtToken events for Aave V3

### DIFF
--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Approval.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_event_Approval"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Approval.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Approval.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Approval.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_BorrowAllowanceDelegated.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_event_BorrowAllowanceDelegated"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_BorrowAllowanceDelegated.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_BorrowAllowanceDelegated.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_BorrowAllowanceDelegated.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_BorrowAllowanceDelegated.json
@@ -31,7 +31,7 @@
             "name": "BorrowAllowanceDelegated",
             "type": "event"
         },
-        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Burn.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Burn.json
@@ -43,7 +43,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Burn.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Burn.json
@@ -48,7 +48,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Burn.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Burn.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_event_Burn"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Initialized.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Initialized.json
@@ -54,7 +54,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Initialized.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_event_Initialized"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Initialized.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Initialized.json
@@ -49,7 +49,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Mint.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Mint.json
@@ -55,7 +55,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Mint.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Mint.json
@@ -1,0 +1,109 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "currentBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "avgStableRate",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newTotalSupply",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "currentBalance",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "avgStableRate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTotalSupply",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_event_Mint"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Mint.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Mint.json
@@ -60,7 +60,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "contract_address": "SELECT stableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY stableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Transfer.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/StableDebtToken_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT stableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY stableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "StableDebtToken_event_Transfer"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Approval.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Approval.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Approval.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Approval.json
@@ -25,7 +25,7 @@
             "name": "Approval",
             "type": "event"
         },
-        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Approval.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Approval.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "spender",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_event_Approval"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_BorrowAllowanceDelegated.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_BorrowAllowanceDelegated.json
@@ -31,7 +31,7 @@
             "name": "BorrowAllowanceDelegated",
             "type": "event"
         },
-        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_BorrowAllowanceDelegated.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_BorrowAllowanceDelegated.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toUser",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowAllowanceDelegated",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "fromUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "toUser",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_event_BorrowAllowanceDelegated"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_BorrowAllowanceDelegated.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_BorrowAllowanceDelegated.json
@@ -36,7 +36,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Burn.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Burn.json
@@ -42,7 +42,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Burn.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Burn.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "target",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "target",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_event_Burn"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Burn.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Burn.json
@@ -37,7 +37,7 @@
             "name": "Burn",
             "type": "event"
         },
-        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Initialized.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Initialized.json
@@ -54,7 +54,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Initialized.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Initialized.json
@@ -49,7 +49,7 @@
             "name": "Initialized",
             "type": "event"
         },
-        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Initialized.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Initialized.json
@@ -1,0 +1,98 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "underlyingAsset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "incentivesController",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "debtTokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenName",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "debtTokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "params",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "underlyingAsset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pool",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "incentivesController",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenDecimals",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenName",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtTokenSymbol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "params",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_event_Initialized"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Mint.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Mint.json
@@ -37,7 +37,7 @@
             "name": "Mint",
             "type": "event"
         },
-        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Mint.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Mint.json
@@ -42,7 +42,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Mint.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Mint.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "onBehalfOf",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "balanceIncrease",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "index",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "caller",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "onBehalfOf",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "balanceIncrease",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "index",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_event_Mint"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Transfer.json
@@ -30,7 +30,7 @@
         "type": "log"
     },
     "table": {
-        "dataset_name": "polygon_aave",
+        "dataset_name": "aave",
         "schema": [
             {
                 "description": "",

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "contract_address": "SELECT variableDebtToken FROM ref('PoolConfigurator_v3_event_ReserveInitialized') GROUP BY variableDebtToken",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/aave/VariableDebtToken_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT variableDebtToken FROM ref(`PoolConfigurator_v3_event_ReserveInitialized`) GROUP BY variableDebtToken",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "polygon_aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "VariableDebtToken_event_Transfer"
+    }
+}


### PR DESCRIPTION
# Changes
Adds StableDebtToken and VariableDebtToken events for Aave V3's Polygon deployment

Used the contract parser ABI: https://nansen-contract-parser-prod.web.app/ to generate these with example [stable](https://polygonscan.com/address/0x40b4baecc69b882e8804f9286b12228c27f8c9bf) and [variable](https://polygonscan.com/address/0x3ca5fa07689f266e907439afd1fbb59c44fe12f6) debt tokens

See this [PR](https://github.com/nansen-ai/evmchain-etl-table-definitions/pull/74) in evmchain-etl-table-definitions for reference

cc @medvedev1088 @TimNooren