### PR TITLE
add element nft marketplace tables

### DIFF
--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155_event_ERC1155BuyOrderFilled.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155_event_ERC1155BuyOrderFilled.json
@@ -1,0 +1,143 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xa4807ef31298b121ef39cd423a8aa05a800b2bb8",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20FillAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct INFTOrdersFeature.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc1155Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc1155TokenId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "erc1155FillAmount",
+                    "type": "uint128"
+                }
+            ],
+            "name": "ERC1155BuyOrderFilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementERC1155_event_ERC1155BuyOrderFilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20FillAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenId",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155FillAmount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155_event_ERC1155BuyOrderPreSigned.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155_event_ERC1155BuyOrderPreSigned.json
@@ -1,0 +1,171 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xa4807ef31298b121ef39cd423a8aa05a800b2bb8",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "expiry",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20TokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "feeData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct LibNFTOrder.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc1155Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc1155TokenId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "contract IPropertyValidator",
+                            "name": "propertyValidator",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "propertyData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct LibNFTOrder.Property[]",
+                    "name": "erc1155TokenProperties",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "erc1155TokenAmount",
+                    "type": "uint128"
+                }
+            ],
+            "name": "ERC1155BuyOrderPreSigned",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementERC1155_event_ERC1155BuyOrderPreSigned",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "expiry",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20TokenAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenId",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenProperties",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenAmount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155_event_ERC1155OrderCancelled.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155_event_ERC1155OrderCancelled.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xa4807ef31298b121ef39cd423a8aa05a800b2bb8",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC1155OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementERC1155_event_ERC1155OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155_event_ERC1155SellOrderFilled.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155_event_ERC1155SellOrderFilled.json
@@ -1,0 +1,143 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xa4807ef31298b121ef39cd423a8aa05a800b2bb8",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20FillAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct INFTOrdersFeature.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc1155Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc1155TokenId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "erc1155FillAmount",
+                    "type": "uint128"
+                }
+            ],
+            "name": "ERC1155SellOrderFilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementERC1155_event_ERC1155SellOrderFilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20FillAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenId",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155FillAmount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155_event_ERC1155SellOrderPreSigned.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155_event_ERC1155SellOrderPreSigned.json
@@ -1,0 +1,148 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xa4807ef31298b121ef39cd423a8aa05a800b2bb8",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "expiry",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20TokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "feeData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct LibNFTOrder.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc1155Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc1155TokenId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "erc1155TokenAmount",
+                    "type": "uint128"
+                }
+            ],
+            "name": "ERC1155SellOrderPreSigned",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementERC1155_event_ERC1155SellOrderPreSigned",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "expiry",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20TokenAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenId",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenAmount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_ERC721BuyOrderFilled.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_ERC721BuyOrderFilled.json
@@ -1,0 +1,132 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20TokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct INFTOrdersFeature.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc721Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc721TokenId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC721BuyOrderFilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementMarketplace_event_ERC721BuyOrderFilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20TokenAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc721Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc721TokenId",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_ERC721BuyOrderPreSigned.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_ERC721BuyOrderPreSigned.json
@@ -1,0 +1,160 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "expiry",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20TokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "feeData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct LibNFTOrder.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc721Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc721TokenId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "contract IPropertyValidator",
+                            "name": "propertyValidator",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "propertyData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct LibNFTOrder.Property[]",
+                    "name": "nftProperties",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "ERC721BuyOrderPreSigned",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementMarketplace_event_ERC721BuyOrderPreSigned",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "expiry",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20TokenAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc721Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc721TokenId",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nftProperties",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_ERC721OrderCancelled.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_ERC721OrderCancelled.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC721OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementMarketplace_event_ERC721OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_ERC721SellOrderFilled.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_ERC721SellOrderFilled.json
@@ -1,0 +1,132 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20TokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct INFTOrdersFeature.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc721Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc721TokenId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC721SellOrderFilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementMarketplace_event_ERC721SellOrderFilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20TokenAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc721Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc721TokenId",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_ERC721SellOrderPreSigned.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_ERC721SellOrderPreSigned.json
@@ -1,0 +1,137 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "expiry",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20TokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "feeData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct LibNFTOrder.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc721Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc721TokenId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC721SellOrderPreSigned",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementMarketplace_event_ERC721SellOrderPreSigned",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "expiry",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20TokenAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc721Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc721TokenId",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_HashNonceIncremented.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_HashNonceIncremented.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newHashNonce",
+                    "type": "uint256"
+                }
+            ],
+            "name": "HashNonceIncremented",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementMarketplace_event_HashNonceIncremented",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "newHashNonce",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_TakerDataEmitted.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementMarketplace_event_TakerDataEmitted.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "takerData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "TakerDataEmitted",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementMarketplace_event_TakerDataEmitted",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerData",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
For the ElementMarketplace tables I used [this contract](https://polygonscan.com/address/0xe89b615a0824286ce1cfed540f4eddf40d2b40e3) to generate the ABI but used [this address](https://polygonscan.com/address/0xeaf5453b329eb38be159a872a6ce91c9a8fb0260) in the tables (proxy implementation) 