### PR TITLE
add element erc1155 events from earlier version

### DIFF
--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_ERC1155BuyOrderFilled.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_ERC1155BuyOrderFilled.json
@@ -1,0 +1,143 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20FillAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct INFTOrdersFeature.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc1155Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc1155TokenId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "erc1155FillAmount",
+                    "type": "uint128"
+                }
+            ],
+            "name": "ERC1155BuyOrderFilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementERC1155V1_event_ERC1155BuyOrderFilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20FillAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenId",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155FillAmount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_ERC1155BuyOrderPreSigned.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_ERC1155BuyOrderPreSigned.json
@@ -1,0 +1,171 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "expiry",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20TokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "feeData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct LibNFTOrder.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc1155Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc1155TokenId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "contract IPropertyValidator",
+                            "name": "propertyValidator",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "propertyData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct LibNFTOrder.Property[]",
+                    "name": "erc1155TokenProperties",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "erc1155TokenAmount",
+                    "type": "uint128"
+                }
+            ],
+            "name": "ERC1155BuyOrderPreSigned",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementERC1155V1_event_ERC1155BuyOrderPreSigned",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "expiry",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20TokenAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenId",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenProperties",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenAmount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_ERC1155OrderCancelled.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_ERC1155OrderCancelled.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC1155OrderCancelled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementERC1155V1_event_ERC1155OrderCancelled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_ERC1155SellOrderFilled.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_ERC1155SellOrderFilled.json
@@ -1,0 +1,143 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20FillAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct INFTOrdersFeature.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc1155Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc1155TokenId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "erc1155FillAmount",
+                    "type": "uint128"
+                }
+            ],
+            "name": "ERC1155SellOrderFilled",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementERC1155V1_event_ERC1155SellOrderFilled",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20FillAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenId",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155FillAmount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_ERC1155SellOrderPreSigned.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_ERC1155SellOrderPreSigned.json
@@ -1,0 +1,148 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "maker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "taker",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "expiry",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "contract IERC20",
+                    "name": "erc20Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc20TokenAmount",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "recipient",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "feeData",
+                            "type": "bytes"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct LibNFTOrder.Fee[]",
+                    "name": "fees",
+                    "type": "tuple[]"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "erc1155Token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "erc1155TokenId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "erc1155TokenAmount",
+                    "type": "uint128"
+                }
+            ],
+            "name": "ERC1155SellOrderPreSigned",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementERC1155V1_event_ERC1155SellOrderPreSigned",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "maker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "taker",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "expiry",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc20TokenAmount",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "fees",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155Token",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenId",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "erc1155TokenAmount",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_TakerDataEmitted.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/element/ElementERC1155V1_event_TakerDataEmitted.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "type": "log",
+        "contract_address": "0xeaf5453b329eb38be159a872a6ce91c9a8fb0260",
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "takerData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "TakerDataEmitted",
+            "type": "event"
+        },
+        "field_mapping": {}
+    },
+    "table": {
+        "dataset_name": "element",
+        "table_name": "ElementERC1155V1_event_TakerDataEmitted",
+        "table_description": "",
+        "schema": [
+            {
+                "name": "orderHash",
+                "description": "",
+                "type": "STRING"
+            },
+            {
+                "name": "takerData",
+                "description": "",
+                "type": "STRING"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
hi! [this](https://polygonscan.com/address/0xc7d7ae0ba2029baea68fbc3c74f7e7832365ef86) appears the original implementation of ERC1155OrdersFeature for Element despite it not getting picked up as an implementation by Polygonscan, it has the same creator (0x9863) as the Marketplace + other implementations 

i can make the v2 version of the ERC1155OrdersFeature now have the V2 labeling but i wasn't sure if that would break anything for anyone else that might be using these tables 