### PR TITLE
Add support for Mai Finance

### DIFF
--- a/airflow/dags/resources/stages/parse/table_definitions/mai/Anchor_call_swapFrom.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/Anchor_call_swapFrom.json
@@ -1,0 +1,33 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "swapFrom",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x947d711c25220d8301c087b25ba111fe8cbf6672', '0x6062e92599a77e62e0cc9749261eb2eac3abd44f', '0xa4742a65f24291aa421497221aaf64c70b098d98'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Anchor_call_swapFrom"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/Anchor_call_swapTo.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/Anchor_call_swapTo.json
@@ -1,0 +1,33 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "swapTo",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x947d711c25220d8301c087b25ba111fe8cbf6672', '0x6062e92599a77e62e0cc9749261eb2eac3abd44f', '0xa4742a65f24291aa421497221aaf64c70b098d98'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Anchor_call_swapTo"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/Anchor_call_transferToken.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/Anchor_call_transferToken.json
@@ -1,0 +1,42 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "name": "amountToken",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferToken",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x947d711c25220d8301c087b25ba111fe8cbf6672', '0x6062e92599a77e62e0cc9749261eb2eac3abd44f', '0xa4742a65f24291aa421497221aaf64c70b098d98'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountToken",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Anchor_call_transferToken"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_call_add.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_call_add.json
@@ -1,0 +1,64 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_allocPoint",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "contract IERC20",
+                    "name": "_lpToken",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "_withUpdate",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "uint16",
+                    "name": "_depositFeeBP",
+                    "type": "uint16"
+                }
+            ],
+            "name": "add",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x9f9f0456005ed4e7248199b6260752e95682a883', '0xcc54afcecd0d89e0b2db58f5d9e58468e7ad20dc', '0x1871178527a5f423f344b2c668e64a02d8783b8b', '0xbd9e831826786d9f2561695a140231f3353c608c', '0x8a75d9337e96d20c10e2632dffe093e5cdbf52bd', '0x574fe4e8120c4da1741b5fd45584de7a5b521f0f', '0x0635af5ab29fc7bba007b8cebad27b7a3d3d1958', '0xffd2aa58cca3a44120aaa42cea2852348a9c2ea6', '0xbd9e831826786d9f2561695a140231f3353c608c'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "_allocPoint",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_lpToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_withUpdate",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_depositFeeBP",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Farm_call_add"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_call_deposit.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_call_deposit.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_pid",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "deposit",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x9f9f0456005ed4e7248199b6260752e95682a883', '0xcc54afcecd0d89e0b2db58f5d9e58468e7ad20dc', '0x1871178527a5f423f344b2c668e64a02d8783b8b', '0xbd9e831826786d9f2561695a140231f3353c608c', '0x8a75d9337e96d20c10e2632dffe093e5cdbf52bd', '0x574fe4e8120c4da1741b5fd45584de7a5b521f0f', '0x0635af5ab29fc7bba007b8cebad27b7a3d3d1958', '0xffd2aa58cca3a44120aaa42cea2852348a9c2ea6', '0xbd9e831826786d9f2561695a140231f3353c608c'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "_pid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Farm_call_deposit"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_call_fund.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_call_fund.json
@@ -1,0 +1,34 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "fund",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x9f9f0456005ed4e7248199b6260752e95682a883', '0xcc54afcecd0d89e0b2db58f5d9e58468e7ad20dc', '0x1871178527a5f423f344b2c668e64a02d8783b8b', '0xbd9e831826786d9f2561695a140231f3353c608c', '0x8a75d9337e96d20c10e2632dffe093e5cdbf52bd', '0x574fe4e8120c4da1741b5fd45584de7a5b521f0f', '0x0635af5ab29fc7bba007b8cebad27b7a3d3d1958', '0xffd2aa58cca3a44120aaa42cea2852348a9c2ea6', '0xbd9e831826786d9f2561695a140231f3353c608c'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Farm_call_fund"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_call_withdraw.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_call_withdraw.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_pid",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "withdraw",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x9f9f0456005ed4e7248199b6260752e95682a883', '0xcc54afcecd0d89e0b2db58f5d9e58468e7ad20dc', '0x1871178527a5f423f344b2c668e64a02d8783b8b', '0xbd9e831826786d9f2561695a140231f3353c608c', '0x8a75d9337e96d20c10e2632dffe093e5cdbf52bd', '0x574fe4e8120c4da1741b5fd45584de7a5b521f0f', '0x0635af5ab29fc7bba007b8cebad27b7a3d3d1958', '0xffd2aa58cca3a44120aaa42cea2852348a9c2ea6', '0xbd9e831826786d9f2561695a140231f3353c608c'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "_pid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Farm_call_withdraw"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_event_Deposit.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_event_Deposit.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "pid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposit",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x9f9f0456005ed4e7248199b6260752e95682a883', '0xcc54afcecd0d89e0b2db58f5d9e58468e7ad20dc', '0x1871178527a5f423f344b2c668e64a02d8783b8b', '0xbd9e831826786d9f2561695a140231f3353c608c', '0x8a75d9337e96d20c10e2632dffe093e5cdbf52bd', '0x574fe4e8120c4da1741b5fd45584de7a5b521f0f', '0x0635af5ab29fc7bba007b8cebad27b7a3d3d1958', '0xffd2aa58cca3a44120aaa42cea2852348a9c2ea6', '0xbd9e831826786d9f2561695a140231f3353c608c'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Farm_event_Deposit"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_event_EmergencyWithdraw.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_event_EmergencyWithdraw.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "pid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "EmergencyWithdraw",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x9f9f0456005ed4e7248199b6260752e95682a883', '0xcc54afcecd0d89e0b2db58f5d9e58468e7ad20dc', '0x1871178527a5f423f344b2c668e64a02d8783b8b', '0xbd9e831826786d9f2561695a140231f3353c608c', '0x8a75d9337e96d20c10e2632dffe093e5cdbf52bd', '0x574fe4e8120c4da1741b5fd45584de7a5b521f0f', '0x0635af5ab29fc7bba007b8cebad27b7a3d3d1958', '0xffd2aa58cca3a44120aaa42cea2852348a9c2ea6', '0xbd9e831826786d9f2561695a140231f3353c608c'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Farm_event_EmergencyWithdraw"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_event_Withdraw.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/Farm_event_Withdraw.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "pid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdraw",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x9f9f0456005ed4e7248199b6260752e95682a883', '0xcc54afcecd0d89e0b2db58f5d9e58468e7ad20dc', '0x1871178527a5f423f344b2c668e64a02d8783b8b', '0xbd9e831826786d9f2561695a140231f3353c608c', '0x8a75d9337e96d20c10e2632dffe093e5cdbf52bd', '0x574fe4e8120c4da1741b5fd45584de7a5b521f0f', '0x0635af5ab29fc7bba007b8cebad27b7a3d3d1958', '0xffd2aa58cca3a44120aaa42cea2852348a9c2ea6', '0xbd9e831826786d9f2561695a140231f3353c608c'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "pid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Farm_event_Withdraw"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_borrowToken.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_borrowToken.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "borrowToken",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_call_borrowToken"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_createVault.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_createVault.json
@@ -1,0 +1,28 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [],
+            "name": "createVault",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [],
+        "table_description": "",
+        "table_name": "MaiVault_call_createVault"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_depositCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_depositCollateral.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "depositCollateral",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_call_depositCollateral"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_destroyVault.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_destroyVault.json
@@ -1,0 +1,34 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                }
+            ],
+            "name": "destroyVault",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_call_destroyVault"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_liquidateVault.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_liquidateVault.json
@@ -1,0 +1,34 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                }
+            ],
+            "name": "liquidateVault",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_call_liquidateVault"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_payBackToken.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_payBackToken.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "payBackToken",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_call_payBackToken"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_safeTransferFrom.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_safeTransferFrom.json
@@ -1,0 +1,64 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "_data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "safeTransferFrom",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "_data",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_call_safeTransferFrom"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_transferFrom.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_transferFrom.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferFrom",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_call_transferFrom"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_transferOwnership.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_transferOwnership.json
@@ -1,0 +1,34 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "transferOwnership",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_call_transferOwnership"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_transferToken.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_transferToken.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amountToken",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferToken",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amountToken",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_call_transferToken"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_withdrawCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_call_withdrawCollateral.json
@@ -1,0 +1,44 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "withdrawCollateral",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_call_withdrawCollateral"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_BorrowToken.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_BorrowToken.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowToken",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_event_BorrowToken"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_CreateVault.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_CreateVault.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "creator",
+                    "type": "address"
+                }
+            ],
+            "name": "CreateVault",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "creator",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_event_CreateVault"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_DepositCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_DepositCollateral.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DepositCollateral",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_event_DepositCollateral"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_DestroyVault.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_DestroyVault.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DestroyVault",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_event_DestroyVault"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_LiquidateVault.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_LiquidateVault.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "buyer",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "debtRepaid",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collateralLiquidated",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "closingFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidateVault",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "owner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "buyer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "debtRepaid",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateralLiquidated",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "closingFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_event_LiquidateVault"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_OwnershipTransferred.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_OwnershipTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "previousOwner",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newOwner",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_event_OwnershipTransferred"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_PayBackToken.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_PayBackToken.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "closingFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PayBackToken",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "closingFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_event_PayBackToken"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "tokenId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_event_Transfer"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_TransferVault.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_TransferVault.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                }
+            ],
+            "name": "TransferVault",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_event_TransferVault"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_WithdrawCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/MaiVault_event_WithdrawCollateral.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "vaultID",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawCollateral",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0xa3fa99a148fa48d14ed51d610c367c61876997f1', '0x3fd939b017b31eaadf9ae50c7ff7fa5c0661d47c', '0x61167073e31b1dad85a3e531211c7b8f1e5cae72', '0x87ee36f780ae843a78d5735867bc1c13792b7b11', '0x98b5f32dd9670191568b661a3e847ed764943875', '0x701a1824e5574b0b6b1c8da808b184a7ab7a2867', '0x649aa6e6b6194250c077df4fb37c23ee6c098513', '0x37131aedd3da288467b6ebe9a77c523a700e6ca1', '0xf086dedf6a89e7b16145b03a6cb0c0a9979f1433', '0x88d84a85a87ed12b8f098e8953b322ff789fcd1a', '0x11a33631a5b5349af3f165d2b7901a4d67e561ad', '0x578375c3af7d61586c2c3a7ba87d2eed640efa40', '0x7dda5e1a389e0c1892caf55940f5fce6588a9ae0', '0xd2fe44055b5c874fee029119f70336447c8e8827', '0x57cbf36788113237d64e46f25a88855c3dff1691', '0xff2c44fb819757225a176e825255a01b3b8bb051', '0x7cbf49e4214c7200af986bc4aacf7bc79dd9c19a', '0x506533b9c16ee2472a6bf37cc320ae45a0a24f11', '0x7d36999a69f2b99bf3fb98866cbbe47af43696c8', '0x1f0aa72b980d65518e88841ba1da075bd43fa933', '0x178f1c95c85fe7221c7a6a3d6f12b7da3253eeae', '0x305f113ff78255d4f8524c8f50c7300b91b10f6a', '0x1dcc1f864a4bd0b8f4ad33594b758b68e9fa872c', '0xaa19d0e397c964a35e6e80262c692dbfc9c23451', '0x11826d20b6a16a22450978642404da95b4640123', '0xa3b0a659f2147d77a443f70d96b3cc95e7a26390', '0x7d75f83f0abe2ece0b9daf41cceddf38cb66146b'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "vaultID",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "MaiVault_event_WithdrawCollateral"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/QI_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/QI_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "QI_event_Transfer"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/camToken_call_enter.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/camToken_call_enter.json
@@ -1,0 +1,34 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "enter",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x22965e296d9a0cd0e917d6d70ef2573009f8a1bb', '0xe6c23289ba5a9f0ef31b8eb36241d5c800889b7b', '0x0470cd31c8fcc42671465880ba81d631f0b76c1d', '0xb3911259f435b28ec072e4ff6ff5a2c604fea0fb', '0x7068ea5255cb05931efa8026bd04b18f3deb8b0b', '0xea4040b21cb68afb94889cb60834b13427cfc4eb', '0xba6273a78a23169e01317bd0f6338547f869e8df'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "_amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "camToken_call_enter"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/camToken_call_leave.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/camToken_call_leave.json
@@ -1,0 +1,34 @@
+{
+    "parser": {
+        "abi": {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_share",
+                    "type": "uint256"
+                }
+            ],
+            "name": "leave",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x22965e296d9a0cd0e917d6d70ef2573009f8a1bb', '0xe6c23289ba5a9f0ef31b8eb36241d5c800889b7b', '0x0470cd31c8fcc42671465880ba81d631f0b76c1d', '0xb3911259f435b28ec072e4ff6ff5a2c604fea0fb', '0x7068ea5255cb05931efa8026bd04b18f3deb8b0b', '0xea4040b21cb68afb94889cb60834b13427cfc4eb', '0xba6273a78a23169e01317bd0f6338547f869e8df'])",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "_share",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "camToken_call_leave"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/camToken_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/camToken_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "SELECT * FROM UNNEST(['0x22965e296d9a0cd0e917d6d70ef2573009f8a1bb', '0xe6c23289ba5a9f0ef31b8eb36241d5c800889b7b', '0x0470cd31c8fcc42671465880ba81d631f0b76c1d', '0xb3911259f435b28ec072e4ff6ff5a2c604fea0fb', '0x7068ea5255cb05931efa8026bd04b18f3deb8b0b', '0xea4040b21cb68afb94889cb60834b13427cfc4eb', '0xba6273a78a23169e01317bd0f6338547f869e8df'])",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "camToken_event_Transfer"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/escrowedQi_event_Enter.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/escrowedQi_event_Enter.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "endBlock",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Enter",
+            "type": "event"
+        },
+        "contract_address": "0x880decade22ad9c58a8a4202ef143c4f305100b3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "endBlock",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "escrowedQi_event_Enter"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/escrowedQi_event_Leave.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/escrowedQi_event_Leave.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "user",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "endBlock",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Leave",
+            "type": "event"
+        },
+        "contract_address": "0x880decade22ad9c58a8a4202ef143c4f305100b3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "user",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "endBlock",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "escrowedQi_event_Leave"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/mai/escrowedQi_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/mai/escrowedQi_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0x880decade22ad9c58a8a4202ef143c4f305100b3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "mai",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "escrowedQi_event_Transfer"
+    }
+}


### PR DESCRIPTION
What?
Adding support for Mai Finance

How?
Used [contract parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions

Note: The protocol does not use factories or registries, so vaults and pools have to be added over time (manually). 