### PR TITLE
[Gauntlet] add Comp v3

### DIFF
--- a/airflow/dags/resources/stages/parse/table_definitions/compound/CometRewards_v3_event_GovernorTransferred.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/CometRewards_v3_event_GovernorTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldGovernor",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newGovernor",
+                    "type": "address"
+                }
+            ],
+            "name": "GovernorTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x1b0e765f6224c21223aea2af16c1c46e38885a40",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldGovernor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newGovernor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "CometRewards_v3_event_GovernorTransferred"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/CometRewards_v3_event_GovernorTransferred.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/CometRewards_v3_event_GovernorTransferred.json
@@ -19,7 +19,7 @@
             "name": "GovernorTransferred",
             "type": "event"
         },
-        "contract_address": "0x1b0e765f6224c21223aea2af16c1c46e38885a40",
+        "contract_address": "0x45939657d1ca34a8fa39a924b71d28fe8431e581",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/CometRewards_v3_event_RewardClaimed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/CometRewards_v3_event_RewardClaimed.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RewardClaimed",
+            "type": "event"
+        },
+        "contract_address": "0x1b0e765f6224c21223aea2af16c1c46e38885a40",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "src",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "token",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "CometRewards_v3_event_RewardClaimed"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/CometRewards_v3_event_RewardClaimed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/CometRewards_v3_event_RewardClaimed.json
@@ -31,7 +31,7 @@
             "name": "RewardClaimed",
             "type": "event"
         },
-        "contract_address": "0x1b0e765f6224c21223aea2af16c1c46e38885a40",
+        "contract_address": "0x45939657d1ca34a8fa39a924b71d28fe8431e581",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_AddAsset.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_AddAsset.json
@@ -1,0 +1,117 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "asset",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "priceFeed",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidateCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidationFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint128",
+                            "name": "supplyCap",
+                            "type": "uint128"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CometConfiguration.AssetConfig",
+                    "name": "assetConfig",
+                    "type": "tuple"
+                }
+            ],
+            "name": "AddAsset",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "asset",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "priceFeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "decimals",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidateCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyCap",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "assetConfig",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_AddAsset"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_AddAsset.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_AddAsset.json
@@ -56,7 +56,7 @@
             "name": "AddAsset",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_CometDeployed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_CometDeployed.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newComet",
+                    "type": "address"
+                }
+            ],
+            "name": "CometDeployed",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newComet",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_CometDeployed"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_CometDeployed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_CometDeployed.json
@@ -19,7 +19,7 @@
             "name": "CometDeployed",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_GovernorTransferred.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_GovernorTransferred.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldGovernor",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newGovernor",
+                    "type": "address"
+                }
+            ],
+            "name": "GovernorTransferred",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldGovernor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newGovernor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_GovernorTransferred"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_GovernorTransferred.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_GovernorTransferred.json
@@ -19,7 +19,7 @@
             "name": "GovernorTransferred",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseBorrowMin.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseBorrowMin.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "oldBaseBorrowMin",
+                    "type": "uint104"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "newBaseBorrowMin",
+                    "type": "uint104"
+                }
+            ],
+            "name": "SetBaseBorrowMin",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBaseBorrowMin",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBaseBorrowMin",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetBaseBorrowMin"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseBorrowMin.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseBorrowMin.json
@@ -25,7 +25,7 @@
             "name": "SetBaseBorrowMin",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseMinForRewards.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseMinForRewards.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "oldBaseMinForRewards",
+                    "type": "uint104"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "newBaseMinForRewards",
+                    "type": "uint104"
+                }
+            ],
+            "name": "SetBaseMinForRewards",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBaseMinForRewards",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBaseMinForRewards",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetBaseMinForRewards"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseMinForRewards.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseMinForRewards.json
@@ -25,7 +25,7 @@
             "name": "SetBaseMinForRewards",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTokenPriceFeed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTokenPriceFeed.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldBaseTokenPriceFeed",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newBaseTokenPriceFeed",
+                    "type": "address"
+                }
+            ],
+            "name": "SetBaseTokenPriceFeed",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBaseTokenPriceFeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBaseTokenPriceFeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetBaseTokenPriceFeed"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTokenPriceFeed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTokenPriceFeed.json
@@ -25,7 +25,7 @@
             "name": "SetBaseTokenPriceFeed",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTrackingBorrowSpeed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTrackingBorrowSpeed.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldBaseTrackingBorrowSpeed",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newBaseTrackingBorrowSpeed",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBaseTrackingBorrowSpeed",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBaseTrackingBorrowSpeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBaseTrackingBorrowSpeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetBaseTrackingBorrowSpeed"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTrackingBorrowSpeed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTrackingBorrowSpeed.json
@@ -25,7 +25,7 @@
             "name": "SetBaseTrackingBorrowSpeed",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTrackingSupplySpeed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTrackingSupplySpeed.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldBaseTrackingSupplySpeed",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newBaseTrackingSupplySpeed",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBaseTrackingSupplySpeed",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBaseTrackingSupplySpeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBaseTrackingSupplySpeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetBaseTrackingSupplySpeed"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTrackingSupplySpeed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBaseTrackingSupplySpeed.json
@@ -25,7 +25,7 @@
             "name": "SetBaseTrackingSupplySpeed",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowKink.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowKink.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldKink",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newKink",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBorrowKink",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldKink",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newKink",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetBorrowKink"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowKink.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowKink.json
@@ -25,7 +25,7 @@
             "name": "SetBorrowKink",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateBase.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateBase.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRBase",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRBase",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBorrowPerYearInterestRateBase",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRBase",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRBase",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetBorrowPerYearInterestRateBase"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateBase.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateBase.json
@@ -25,7 +25,7 @@
             "name": "SetBorrowPerYearInterestRateBase",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateSlopeHigh.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateSlopeHigh.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRSlopeHigh",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRSlopeHigh",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBorrowPerYearInterestRateSlopeHigh",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRSlopeHigh",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRSlopeHigh",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetBorrowPerYearInterestRateSlopeHigh"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateSlopeHigh.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateSlopeHigh.json
@@ -25,7 +25,7 @@
             "name": "SetBorrowPerYearInterestRateSlopeHigh",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateSlopeLow.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateSlopeLow.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRSlopeLow",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRSlopeLow",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetBorrowPerYearInterestRateSlopeLow",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRSlopeLow",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRSlopeLow",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetBorrowPerYearInterestRateSlopeLow"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateSlopeLow.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetBorrowPerYearInterestRateSlopeLow.json
@@ -25,7 +25,7 @@
             "name": "SetBorrowPerYearInterestRateSlopeLow",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetConfiguration.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetConfiguration.json
@@ -1,0 +1,556 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "governor",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "pauseGuardian",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "baseToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "baseTokenPriceFeed",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "extensionDelegate",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyKink",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateSlopeLow",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateSlopeHigh",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateBase",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowKink",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateSlopeLow",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateSlopeHigh",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateBase",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "storeFrontPriceFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "trackingIndexScale",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "baseTrackingSupplySpeed",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "baseTrackingBorrowSpeed",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "baseMinForRewards",
+                            "type": "uint104"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "baseBorrowMin",
+                            "type": "uint104"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "targetReserves",
+                            "type": "uint104"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "asset",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "priceFeed",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint8",
+                                    "name": "decimals",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "borrowCollateralFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "liquidateCollateralFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "liquidationFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint128",
+                                    "name": "supplyCap",
+                                    "type": "uint128"
+                                }
+                            ],
+                            "internalType": "struct CometConfiguration.AssetConfig[]",
+                            "name": "assetConfigs",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CometConfiguration.Configuration",
+                    "name": "oldConfiguration",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "governor",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "pauseGuardian",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "baseToken",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "baseTokenPriceFeed",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "extensionDelegate",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyKink",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateSlopeLow",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateSlopeHigh",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "supplyPerYearInterestRateBase",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowKink",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateSlopeLow",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateSlopeHigh",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowPerYearInterestRateBase",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "storeFrontPriceFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "trackingIndexScale",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "baseTrackingSupplySpeed",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "baseTrackingBorrowSpeed",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "baseMinForRewards",
+                            "type": "uint104"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "baseBorrowMin",
+                            "type": "uint104"
+                        },
+                        {
+                            "internalType": "uint104",
+                            "name": "targetReserves",
+                            "type": "uint104"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "asset",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "priceFeed",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint8",
+                                    "name": "decimals",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "borrowCollateralFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "liquidateCollateralFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "liquidationFactor",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "uint128",
+                                    "name": "supplyCap",
+                                    "type": "uint128"
+                                }
+                            ],
+                            "internalType": "struct CometConfiguration.AssetConfig[]",
+                            "name": "assetConfigs",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CometConfiguration.Configuration",
+                    "name": "newConfiguration",
+                    "type": "tuple"
+                }
+            ],
+            "name": "SetConfiguration",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "governor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pauseGuardian",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseToken",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTokenPriceFeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "extensionDelegate",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyKink",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateSlopeLow",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateSlopeHigh",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateBase",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowKink",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateSlopeLow",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateSlopeHigh",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateBase",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "storeFrontPriceFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "trackingIndexScale",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTrackingSupplySpeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTrackingBorrowSpeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseMinForRewards",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseBorrowMin",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "targetReserves",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "assetConfigs",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "oldConfiguration",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "governor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "pauseGuardian",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseToken",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTokenPriceFeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "extensionDelegate",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyKink",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateSlopeLow",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateSlopeHigh",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyPerYearInterestRateBase",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowKink",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateSlopeLow",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateSlopeHigh",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowPerYearInterestRateBase",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "storeFrontPriceFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "trackingIndexScale",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTrackingSupplySpeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseTrackingBorrowSpeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseMinForRewards",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "baseBorrowMin",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "targetReserves",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "assetConfigs",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "newConfiguration",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetConfiguration"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetConfiguration.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetConfiguration.json
@@ -313,7 +313,7 @@
             "name": "SetConfiguration",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetExtensionDelegate.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetExtensionDelegate.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldExt",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newExt",
+                    "type": "address"
+                }
+            ],
+            "name": "SetExtensionDelegate",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldExt",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newExt",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetExtensionDelegate"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetExtensionDelegate.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetExtensionDelegate.json
@@ -25,7 +25,7 @@
             "name": "SetExtensionDelegate",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetFactory.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetFactory.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldFactory",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newFactory",
+                    "type": "address"
+                }
+            ],
+            "name": "SetFactory",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldFactory",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFactory",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetFactory"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetFactory.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetFactory.json
@@ -25,7 +25,7 @@
             "name": "SetFactory",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetGovernor.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetGovernor.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldGovernor",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newGovernor",
+                    "type": "address"
+                }
+            ],
+            "name": "SetGovernor",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldGovernor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newGovernor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetGovernor"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetGovernor.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetGovernor.json
@@ -25,7 +25,7 @@
             "name": "SetGovernor",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetPauseGuardian.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetPauseGuardian.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldPauseGuardian",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newPauseGuardian",
+                    "type": "address"
+                }
+            ],
+            "name": "SetPauseGuardian",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldPauseGuardian",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPauseGuardian",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetPauseGuardian"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetPauseGuardian.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetPauseGuardian.json
@@ -25,7 +25,7 @@
             "name": "SetPauseGuardian",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetStoreFrontPriceFactor.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetStoreFrontPriceFactor.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldStoreFrontPriceFactor",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newStoreFrontPriceFactor",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetStoreFrontPriceFactor",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldStoreFrontPriceFactor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newStoreFrontPriceFactor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetStoreFrontPriceFactor"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetStoreFrontPriceFactor.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetStoreFrontPriceFactor.json
@@ -25,7 +25,7 @@
             "name": "SetStoreFrontPriceFactor",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyKink.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyKink.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldKink",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newKink",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetSupplyKink",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldKink",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newKink",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetSupplyKink"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyKink.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyKink.json
@@ -25,7 +25,7 @@
             "name": "SetSupplyKink",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateBase.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateBase.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRBase",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRBase",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetSupplyPerYearInterestRateBase",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRBase",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRBase",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetSupplyPerYearInterestRateBase"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateBase.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateBase.json
@@ -25,7 +25,7 @@
             "name": "SetSupplyPerYearInterestRateBase",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateSlopeHigh.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateSlopeHigh.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRSlopeHigh",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRSlopeHigh",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetSupplyPerYearInterestRateSlopeHigh",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRSlopeHigh",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRSlopeHigh",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetSupplyPerYearInterestRateSlopeHigh"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateSlopeHigh.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateSlopeHigh.json
@@ -25,7 +25,7 @@
             "name": "SetSupplyPerYearInterestRateSlopeHigh",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateSlopeLow.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateSlopeLow.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldIRSlopeLow",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newIRSlopeLow",
+                    "type": "uint64"
+                }
+            ],
+            "name": "SetSupplyPerYearInterestRateSlopeLow",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldIRSlopeLow",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newIRSlopeLow",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetSupplyPerYearInterestRateSlopeLow"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateSlopeLow.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetSupplyPerYearInterestRateSlopeLow.json
@@ -25,7 +25,7 @@
             "name": "SetSupplyPerYearInterestRateSlopeLow",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetTargetReserves.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetTargetReserves.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "oldTargetReserves",
+                    "type": "uint104"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint104",
+                    "name": "newTargetReserves",
+                    "type": "uint104"
+                }
+            ],
+            "name": "SetTargetReserves",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldTargetReserves",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newTargetReserves",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_SetTargetReserves"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetTargetReserves.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_SetTargetReserves.json
@@ -25,7 +25,7 @@
             "name": "SetTargetReserves",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAsset.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAsset.json
@@ -1,0 +1,202 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "asset",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "priceFeed",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidateCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidationFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint128",
+                            "name": "supplyCap",
+                            "type": "uint128"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CometConfiguration.AssetConfig",
+                    "name": "oldAssetConfig",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "asset",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "priceFeed",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "borrowCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidateCollateralFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "liquidationFactor",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "uint128",
+                            "name": "supplyCap",
+                            "type": "uint128"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct CometConfiguration.AssetConfig",
+                    "name": "newAssetConfig",
+                    "type": "tuple"
+                }
+            ],
+            "name": "UpdateAsset",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "asset",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "priceFeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "decimals",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidateCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyCap",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "oldAssetConfig",
+                "type": "RECORD"
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "description": "",
+                        "name": "asset",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "priceFeed",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "decimals",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "borrowCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidateCollateralFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "liquidationFactor",
+                        "type": "STRING"
+                    },
+                    {
+                        "description": "",
+                        "name": "supplyCap",
+                        "type": "STRING"
+                    }
+                ],
+                "name": "newAssetConfig",
+                "type": "RECORD"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_UpdateAsset"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAsset.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAsset.json
@@ -99,7 +99,7 @@
             "name": "UpdateAsset",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetBorrowCollateralFactor.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetBorrowCollateralFactor.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldBorrowCF",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newBorrowCF",
+                    "type": "uint64"
+                }
+            ],
+            "name": "UpdateAssetBorrowCollateralFactor",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBorrowCF",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowCF",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_UpdateAssetBorrowCollateralFactor"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetBorrowCollateralFactor.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetBorrowCollateralFactor.json
@@ -31,7 +31,7 @@
             "name": "UpdateAssetBorrowCollateralFactor",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetLiquidateCollateralFactor.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetLiquidateCollateralFactor.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldLiquidateCF",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newLiquidateCF",
+                    "type": "uint64"
+                }
+            ],
+            "name": "UpdateAssetLiquidateCollateralFactor",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldLiquidateCF",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newLiquidateCF",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_UpdateAssetLiquidateCollateralFactor"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetLiquidateCollateralFactor.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetLiquidateCollateralFactor.json
@@ -31,7 +31,7 @@
             "name": "UpdateAssetLiquidateCollateralFactor",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetLiquidationFactor.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetLiquidationFactor.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "oldLiquidationFactor",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "newLiquidationFactor",
+                    "type": "uint64"
+                }
+            ],
+            "name": "UpdateAssetLiquidationFactor",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldLiquidationFactor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newLiquidationFactor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_UpdateAssetLiquidationFactor"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetLiquidationFactor.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetLiquidationFactor.json
@@ -31,7 +31,7 @@
             "name": "UpdateAssetLiquidationFactor",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetPriceFeed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetPriceFeed.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldPriceFeed",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newPriceFeed",
+                    "type": "address"
+                }
+            ],
+            "name": "UpdateAssetPriceFeed",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldPriceFeed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newPriceFeed",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_UpdateAssetPriceFeed"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetPriceFeed.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetPriceFeed.json
@@ -31,7 +31,7 @@
             "name": "UpdateAssetPriceFeed",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetSupplyCap.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetSupplyCap.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "cometProxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldSupplyCap",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newSupplyCap",
+                    "type": "uint128"
+                }
+            ],
+            "name": "UpdateAssetSupplyCap",
+            "type": "event"
+        },
+        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "cometProxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldSupplyCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Configurator_v3_event_UpdateAssetSupplyCap"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetSupplyCap.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/Configurator_v3_event_UpdateAssetSupplyCap.json
@@ -31,7 +31,7 @@
             "name": "UpdateAssetSupplyCap",
             "type": "event"
         },
-        "contract_address": "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3",
+        "contract_address": "0x83e0f742cacbe66349e3701b171ee2487a26e738",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_AbsorbCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_AbsorbCollateral.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "absorber",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collateralAbsorbed",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "usdValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AbsorbCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "absorber",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateralAbsorbed",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "usdValue",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_AbsorbCollateral"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_AbsorbCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_AbsorbCollateral.json
@@ -37,7 +37,7 @@
             "name": "AbsorbCollateral",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xf25212e676d1f7f89cd72ffee66158f541246445",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_AbsorbDebt.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_AbsorbDebt.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "absorber",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "borrower",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "basePaidOut",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "usdValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AbsorbDebt",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "absorber",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrower",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "basePaidOut",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "usdValue",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_AbsorbDebt"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_AbsorbDebt.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_AbsorbDebt.json
@@ -31,7 +31,7 @@
             "name": "AbsorbDebt",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xf25212e676d1f7f89cd72ffee66158f541246445",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_BuyCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_BuyCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "buyer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "baseAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "collateralAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BuyCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "buyer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "baseAmount",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "collateralAmount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_BuyCollateral"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_BuyCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_BuyCollateral.json
@@ -31,7 +31,7 @@
             "name": "BuyCollateral",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xf25212e676d1f7f89cd72ffee66158f541246445",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_PauseAction.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_PauseAction.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "supplyPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "transferPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "withdrawPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "absorbPaused",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "buyPaused",
+                    "type": "bool"
+                }
+            ],
+            "name": "PauseAction",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "supplyPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "transferPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "withdrawPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "absorbPaused",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "buyPaused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_PauseAction"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_PauseAction.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_PauseAction.json
@@ -37,7 +37,7 @@
             "name": "PauseAction",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xf25212e676d1f7f89cd72ffee66158f541246445",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Supply.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Supply.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Supply",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dst",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_Supply"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Supply.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Supply.json
@@ -25,7 +25,7 @@
             "name": "Supply",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xf25212e676d1f7f89cd72ffee66158f541246445",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_SupplyCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_SupplyCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "dst",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "dst",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_SupplyCollateral"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_SupplyCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_SupplyCollateral.json
@@ -31,7 +31,7 @@
             "name": "SupplyCollateral",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xf25212e676d1f7f89cd72ffee66158f541246445",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Transfer.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_Transfer"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Transfer.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Transfer.json
@@ -25,7 +25,7 @@
             "name": "Transfer",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xf25212e676d1f7f89cd72ffee66158f541246445",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_TransferCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_TransferCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "TransferCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "from",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_TransferCollateral"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_TransferCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_TransferCollateral.json
@@ -31,7 +31,7 @@
             "name": "TransferCollateral",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xf25212e676d1f7f89cd72ffee66158f541246445",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Withdraw.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Withdraw.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdraw",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "src",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_Withdraw"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Withdraw.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_Withdraw.json
@@ -25,7 +25,7 @@
             "name": "Withdraw",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xf25212e676d1f7f89cd72ffee66158f541246445",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_WithdrawCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_WithdrawCollateral.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "src",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawCollateral",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "src",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_WithdrawCollateral"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_WithdrawCollateral.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_WithdrawCollateral.json
@@ -31,7 +31,7 @@
             "name": "WithdrawCollateral",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xf25212e676d1f7f89cd72ffee66158f541246445",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_WithdrawReserves.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_WithdrawReserves.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WithdrawReserves",
+            "type": "event"
+        },
+        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "compound",
+        "schema": [
+            {
+                "description": "",
+                "name": "to",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "amount",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "cUSDCv3_event_WithdrawReserves"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_WithdrawReserves.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/compound/cUSDCv3_event_WithdrawReserves.json
@@ -19,7 +19,7 @@
             "name": "WithdrawReserves",
             "type": "event"
         },
-        "contract_address": "0xc3d688b66703497daa19211eedff47f25384cdc3",
+        "contract_address": "0xf25212e676d1f7f89cd72ffee66158f541246445",
         "field_mapping": {},
         "type": "log"
     },


### PR DESCRIPTION
Adds Comp V3 to polygon-etl.

The events were copied from the [ethereum-etl-airflow](https://github.com/blockchain-etl/ethereum-etl-airflow/tree/aa94c1de9f84301861e267c18d4cfdd490be338f/dags/resources/stages/parse/table_definitions/compound) repo. I replaced the eth contract addresses with polygon addresses following [this table](https://docs.compound.finance/#networks) from the Comp V3 docs.