### PR TITLE
Use confirmAggregator function call in chailink table definitions

### DIFF
--- a/airflow/dags/resources/stages/parse/sqls/parse_logs.sql
+++ b/airflow/dags/resources/stages/parse/sqls/parse_logs.sql
@@ -7,7 +7,21 @@ WITH parsed_logs AS
     ,logs.address AS contract_address
     ,`{{internal_project_id}}.{{dataset_name}}.{{udf_name}}`(logs.data, logs.topics) AS parsed
 FROM `{{full_source_table_name}}` AS logs
+{#
+    Queries that reference more than one table cant be used in the "IN" clause as it produced this error in BigQuery:
+    > Correlated subqueries that reference other tables are not supported unless they can be de-correlated, such as by transforming them into an efficient JOIN.
+    To avoid it we use JOIN instead of the IN clause.
+    For backward compatibility we require marking such queries with the comment /* avoid correlated subquery error */
+    e.g. see chainlink/AccessControlledOffchainAggregator_event_AnswerUpdated.json
+    You need to make sure the query in the contract_address field produces distinct addresses and has a field named address
+#}
+{% if 'avoid correlated subquery error' in parser.contract_address_sql %}
+JOIN ({{parser.contract_address_sql}}) AS join_addresses ON logs.address = join_addresses.address
+{% endif %}
 WHERE
+  {% if 'avoid correlated subquery error' in parser.contract_address_sql %}
+  true
+  {% elif parser.contract_address_sql %}
   {% if parser.contract_address_sql %}
   address in ({{parser.contract_address_sql}})
   {% elif parser.contract_address is none %}

--- a/airflow/dags/resources/stages/parse/table_definitions/chainlink/AccessControlledOffchainAggregator_event_AnswerUpdated.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/chainlink/AccessControlledOffchainAggregator_event_AnswerUpdated.json
@@ -25,7 +25,7 @@
             "name": "AnswerUpdated",
             "type": "event"
         },
-        "contract_address": "SELECT contract_address FROM ref('view_AccessControlledOffchainAggregator_info')",
+        "contract_address": "/* avoid correlated subquery error */ SELECT contract_address AS address FROM ref('view_AccessControlledOffchainAggregator_info') UNION DISTINCT SELECT DISTINCT _aggregator FROM ref('EACAggregatorProxy_call_confirmAggregator')",
         "field_mapping": {},
         "type": "log"
     },

--- a/airflow/dags/resources/stages/parse/table_definitions/chainlink/EACAggregatorProxy_call_confirmAggregator.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/chainlink/EACAggregatorProxy_call_confirmAggregator.json
@@ -1,0 +1,33 @@
+{
+    "parser": {
+        "abi": {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_aggregator",
+                    "type": "address"
+                }
+            ],
+            "name": "confirmAggregator",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        "contract_address": "SELECT proxy_address FROM ref('view_AccessControlledOffchainAggregator_info')",
+        "field_mapping": {},
+        "type": "trace"
+    },
+    "table": {
+        "dataset_name": "chainlink",
+        "schema": [
+            {
+                "description": "",
+                "name": "_aggregator",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "EACAggregatorProxy_call_confirmAggregator"
+    },
+    "version": "1"
+}

--- a/airflow/tests/test_polygonetl_airflow/test_table_definition_reader.py
+++ b/airflow/tests/test_polygonetl_airflow/test_table_definition_reader.py
@@ -28,5 +28,6 @@ def test_read_table_definition_states(dataset_folder):
 
     assert updated_table_definitions == [
         'AccessControlledOffchainAggregator_event_AnswerUpdated',
+        'EACAggregatorProxy_call_confirmAggregator',
         'view_AccessControlledOffchainAggregator_info'
     ]


### PR DESCRIPTION
- Use confirmAggregator function call in chailink table definitions so aggregator addresses are automatically picked up in dependant tables
- Tweak `parse_logs.sql` to avoid "correlated subquery" error

