### PR TITLE
Adding the Bitkeep's fork of Seaport

### DIFF
--- a/airflow/dags/resources/stages/parse/table_definitions/bitkeep/Seaport_event_CounterIncremented.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/bitkeep/Seaport_event_CounterIncremented.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newCounter",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                }
+            ],
+            "name": "CounterIncremented",
+            "type": "event"
+        },
+        "contract_address": "0x309b186792b74cc81497a113555b333ad79ac78c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bitkeep",
+        "schema": [
+            {
+                "description": "",
+                "name": "newCounter",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "offerer",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Seaport_event_CounterIncremented"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/bitkeep/Seaport_event_OrderCancelled.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/bitkeep/Seaport_event_OrderCancelled.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderCancelled",
+            "type": "event"
+        },
+        "contract_address": "0x309b186792b74cc81497a113555b333ad79ac78c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bitkeep",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "offerer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "zone",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Seaport_event_OrderCancelled"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/bitkeep/Seaport_event_OrderFulfilled.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/bitkeep/Seaport_event_OrderFulfilled.json
@@ -1,0 +1,136 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enum ItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct SpentItem[]",
+                    "name": "offer",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "enum ItemType",
+                            "name": "itemType",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "token",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "identifier",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "address payable",
+                            "name": "recipient",
+                            "type": "address"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct ReceivedItem[]",
+                    "name": "consideration",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "OrderFulfilled",
+            "type": "event"
+        },
+        "contract_address": "0x309b186792b74cc81497a113555b333ad79ac78c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bitkeep",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "offerer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "zone",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "recipient",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "offer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "consideration",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Seaport_event_OrderFulfilled"
+    }
+}

--- a/airflow/dags/resources/stages/parse/table_definitions/bitkeep/Seaport_event_OrderValidated.json
+++ b/airflow/dags/resources/stages/parse/table_definitions/bitkeep/Seaport_event_OrderValidated.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "bytes32",
+                    "name": "orderHash",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                }
+            ],
+            "name": "OrderValidated",
+            "type": "event"
+        },
+        "contract_address": "0x309b186792b74cc81497a113555b333ad79ac78c",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "bitkeep",
+        "schema": [
+            {
+                "description": "",
+                "name": "orderHash",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "offerer",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "zone",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "Seaport_event_OrderValidated"
+    }
+}


### PR DESCRIPTION
- Adding the seaport contracts to see the actual order filled and cancel events
- ABI from contract parser
- Added to bitkeep folder since it's Bitkeep's fork of Seaport