### PR TITLE
Remove check for output field in traces file

### DIFF
--- a/cli/polygonetl/jobs/export_geth_traces_job.py
+++ b/cli/polygonetl/jobs/export_geth_traces_job.py
@@ -59,15 +59,6 @@ class ExportGethTracesJob(BaseJob):
                     'Error for trace in block {block}. Need to retry. Error: {err}, trace: {trace}'
                         .format(block=block_number, trace=json.dumps(tx_trace), err=tx_trace.get('error'))
                 )
-            elif (
-                tx_trace.get('result').get('error') is None
-                and tx_trace.get('result').get('output') is None
-            ):
-                err = '`output` fields missing in traces file'
-                raise RetriableValueError(
-                    'Error for trace in block {block}. Need to retry. Error: {err}, result: {result}'
-                        .format(block=block_number, err=err, result=result)
-                )      
 
     def _start(self):
         self.item_exporter.open()


### PR DESCRIPTION
Temporarily remove check for output field in traces file.

Causes error:

```
polygonetl.misc.retriable_value_error.RetriableValueError: Error for trace in block 48339728. Need to retry. Error: `output` fields missing in traces file, result: [{'result': {'from': '0xe6ab66ca47b9c6cf5a0269786e6af86a44ff8c49', 'gas': '0x16e360', 'gasUsed': '0x14956', 'to': '0xdb46d1dc155634fbc732f92e853b10b288ad5a1d', 'input': '0x3b28b89f0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000001e62a0000000000000000000000006640e4fb3fd56a6d7dff3c351dfd9ab7e57fb76900000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000001c4356b6039cf7db03c29577fd0317f645563e7e67180f412f301229c59065afc71fac354fd7f77438ee2cc184af560294ce3c412b6000108d864e7ea6c2608b3700000000000000000000000000000000000000000000000000000000651e20960000000000000000000000000000000000000000000000000000000000000000', 'calls': [{'from': '0xdb46d1dc155634fbc732f92e853b10b288ad5a1d', 'gas': '0x1611f3', 'gasUsed': '0xd171', 'to': '0xba97fc9137b7cbbbc7fcb70a87da645d917c902f', 'input': '0x3b28b89f0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000001e62a0000000000000000000000006640e4fb3fd56a6d7dff3c351dfd9ab7e57fb76900000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000001c4356b6039cf7db03c29577fd0317f645563e7e67180f412f301229c59065afc71fac354fd7f77438ee2cc184af560294ce3c412b6000108d864e7ea6c2608b3700000000000000000000000000000000000000000000000000000000651e20960000000000000000000000000000000000000000000000000000000000000000', 'calls': [{'from': '0xdb46d1dc155634fbc732f92e853b10b288ad5a1d', 'gas': '0x1581a1', 'gasUsed': '0xbb8', 'to': '0x0000000000000000000000000000000000000001', 'input': '0x0056f976455e38393e384ab799bf9405fd5db249f9634e37cb6a021b048e476f000000000000000000000000000000000000000000000000000000000000001c4356b6039cf7db03c29577fd0317f645563e7e67180f412f301229c59065afc71fac354fd7f77438ee2cc184af560294ce3c412b600010… [message truncated due to size]
```