### PR TITLE
Validate bytecode in EthContractService.get_function_sighashes

### DIFF
--- a/airflow/requirements_airflow.txt
+++ b/airflow/requirements_airflow.txt
@@ -4,5 +4,5 @@
 
 discord-webhook==1.1.0
 eth-hash==0.3.3     # Fixes install conflicts issue in Composer
-polygon-etl==0.3.7
+polygon-etl==0.3.8
 web3==5.31.0        # Fixes install conflicts issue in Composer

--- a/airflow/requirements_parse.txt
+++ b/airflow/requirements_parse.txt
@@ -1,5 +1,5 @@
 eth-hash==0.3.3                             # Fixes install conflicts issue in Composer
-polygon-etl==0.3.7
+polygon-etl==0.3.8
 web3==5.31.0                                # Fixes install conflicts issue in Composer
 
 google-api-core==2.8.1                      # matches `composer-2.1.14-airflow-2.5.1`

--- a/cli/polygonetl/service/eth_contract_service.py
+++ b/cli/polygonetl/service/eth_contract_service.py
@@ -27,6 +27,9 @@ from ethereum_dasm.evmdasm import EvmCode, Contract
 class EthContractService:
 
     def get_function_sighashes(self, bytecode):
+        if not bytecode:
+            return []
+
         bytecode = clean_bytecode(bytecode)
         if bytecode is not None:
             evm_code = EvmCode(contract=Contract(bytecode=bytecode), static_analysis=False, dynamic_analysis=False)


### PR DESCRIPTION
##What? 

Validate bytecode in EthContractService.get_function_sighashes

## Why?

Starting with Polygon v1.0.4 contract creation traces contain empty string instead of 0x in the `output` field. See https://polygonscan.com/tx/0xcf4742c7f9b5827ec21462f20c554f2e6e1d87a12b7eb58281a91e1eec9521ac for an example