### PR TITLE
delete `polygon_parse_README.md_dag`

### DIFF
--- a/airflow/dags/polygon_parse_dag.py
+++ b/airflow/dags/polygon_parse_dag.py
@@ -21,6 +21,8 @@ parse_dag_vars = read_parse_dag_vars(
 )
 
 for folder in glob(table_definitions_folder):
+    if not os.path.isdir(folder):
+        continue
     dataset = folder.split('/')[-1]
 
     dag_id = f'polygon_parse_{dataset}_dag'


### PR DESCRIPTION
Follow-up to:
https://github.com/blockchain-etl/polygon-etl/pull/206
https://github.com/blockchain-etl/polygon-etl/pull/208

The `README.md` I added to `table_definitions_folder` was generating a new dag `polygon_parse_README.md_dag`. This PR to fix by excluding files such as these.

Testing: already deployed to existing Composer environment.

